### PR TITLE
Fixing size issue in firefox

### DIFF
--- a/packages/akar-icons/package.json
+++ b/packages/akar-icons/package.json
@@ -2,8 +2,8 @@
   "name": "@ng-icons/akar-icons",
   "version": "0.0.1",
   "peerDependencies": {
-    "@angular/common": ">=12.0.0",
-    "@angular/core": ">=12.0.0"
+    "@angular/common": ">=12.0.0 <14.0.0",
+    "@angular/core": ">=12.0.0 <14.0.0"
   },
   "dependencies": {
     "tslib": "^2.2.0"

--- a/packages/bootstrap-icons/package.json
+++ b/packages/bootstrap-icons/package.json
@@ -2,8 +2,8 @@
   "name": "@ng-icons/bootstrap-icons",
   "version": "0.0.1",
   "peerDependencies": {
-    "@angular/common": ">=12.0.0",
-    "@angular/core": ">=12.0.0"
+    "@angular/common": ">=12.0.0 <14.0.0",
+    "@angular/core": ">=12.0.0 <14.0.0"
   },
   "dependencies": {
     "tslib": "^2.2.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,8 +7,8 @@
   },
   "homepage": "https://ng-icons.github.io/ng-icons/",
   "peerDependencies": {
-    "@angular/common": ">=12.0.0",
-    "@angular/core": ">=12.0.0"
+    "@angular/common": ">=12.0.0 <14.0.0",
+    "@angular/core": ">=12.0.0 <14.0.0"
   },
   "dependencies": {
     "tslib": "^2.2.0"

--- a/packages/core/src/lib/icon.component.ts
+++ b/packages/core/src/lib/icon.component.ts
@@ -40,7 +40,16 @@ export class IconComponent {
   /** Define the size of the icon */
   @HostBinding('style.--ng-icon__size')
   @Input()
-  size: string = '1em';
+  set size(size: string) {
+    // if the size only contains numbers, assume it is in pixels
+    this._size =  coerceCssPixelValue(size);
+  }
+
+  get size(): string {
+    return this._size;
+  }
+
+  private _size: string = '1em';
 
   /** Define the stroke-width of the icon */
   @HostBinding('style.--ng-icon__stroke-width')
@@ -57,4 +66,12 @@ export class IconComponent {
     private readonly sanitizer: DomSanitizer,
     private readonly iconService: IconService,
   ) {}
+}
+
+function coerceCssPixelValue(value: string): string {
+  if (value == null) {
+    return '';
+  }
+
+  return /^\d+$/.test(value) ? `${value}px` : value;
 }

--- a/packages/css-gg/package.json
+++ b/packages/css-gg/package.json
@@ -2,8 +2,8 @@
   "name": "@ng-icons/css.gg",
   "version": "0.0.1",
   "peerDependencies": {
-    "@angular/common": ">=12.0.0",
-    "@angular/core": ">=12.0.0"
+    "@angular/common": ">=12.0.0 <14.0.0",
+    "@angular/core": ">=12.0.0 <14.0.0"
   },
   "dependencies": {
     "tslib": "^2.2.0"

--- a/packages/feather-icons/package.json
+++ b/packages/feather-icons/package.json
@@ -7,8 +7,8 @@
   "homepage": "https://ng-icons.github.io/ng-icons/",
   "license": "MIT",
   "peerDependencies": {
-    "@angular/common": ">=12.0.0",
-    "@angular/core": ">=12.0.0"
+    "@angular/common": ">=12.0.0 <14.0.0",
+    "@angular/core": ">=12.0.0 <14.0.0"
   },
   "dependencies": {
     "tslib": "^2.2.0"

--- a/packages/heroicons/package.json
+++ b/packages/heroicons/package.json
@@ -7,8 +7,8 @@
   },
   "homepage": "https://ng-icons.github.io/ng-icons/",
   "peerDependencies": {
-    "@angular/common": ">=12.0.0",
-    "@angular/core": ">=12.0.0"
+    "@angular/common": ">=12.0.0 <14.0.0",
+    "@angular/core": ">=12.0.0 <14.0.0"
   },
   "dependencies": {
     "tslib": "^2.2.0"

--- a/packages/ionicons/package.json
+++ b/packages/ionicons/package.json
@@ -2,8 +2,8 @@
   "name": "@ng-icons/ionicons",
   "version": "0.0.1",
   "peerDependencies": {
-    "@angular/common": ">=12.0.0",
-    "@angular/core": ">=12.0.0"
+    "@angular/common": ">=12.0.0 <14.0.0",
+    "@angular/core": ">=12.0.0 <14.0.0"
   },
   "dependencies": {
     "tslib": "^2.2.0"

--- a/packages/jam-icons/package.json
+++ b/packages/jam-icons/package.json
@@ -7,8 +7,8 @@
   },
   "homepage": "https://ng-icons.github.io/ng-icons/",
   "peerDependencies": {
-    "@angular/common": ">=12.0.0",
-    "@angular/core": ">=12.0.0"
+    "@angular/common": ">=12.0.0 <14.0.0",
+    "@angular/core": ">=12.0.0 <14.0.0"
   },
   "dependencies": {
     "tslib": "^2.2.0"

--- a/packages/material-icons/package.json
+++ b/packages/material-icons/package.json
@@ -2,8 +2,8 @@
   "name": "@ng-icons/material-icons",
   "version": "0.0.1",
   "peerDependencies": {
-    "@angular/common": ">=12.0.0",
-    "@angular/core": ">=12.0.0"
+    "@angular/common": ">=12.0.0 <14.0.0",
+    "@angular/core": ">=12.0.0 <14.0.0"
   },
   "dependencies": {
     "tslib": "^2.2.0"

--- a/packages/octicons/package.json
+++ b/packages/octicons/package.json
@@ -7,8 +7,8 @@
   },
   "homepage": "https://ng-icons.github.io/ng-icons/",
   "peerDependencies": {
-    "@angular/common": ">=12.0.0",
-    "@angular/core": ">=12.0.0"
+    "@angular/common": ">=12.0.0 <14.0.0",
+    "@angular/core": ">=12.0.0 <14.0.0"
   },
   "dependencies": {
     "tslib": "^2.2.0"

--- a/packages/radix-icons/package.json
+++ b/packages/radix-icons/package.json
@@ -7,8 +7,8 @@
   "homepage": "https://ng-icons.github.io/ng-icons/",
   "license": "MIT",
   "peerDependencies": {
-    "@angular/common": ">=12.0.0",
-    "@angular/core": ">=12.0.0"
+    "@angular/common": ">=12.0.0 <14.0.0",
+    "@angular/core": ">=12.0.0 <14.0.0"
   },
   "dependencies": {
     "tslib": "^2.2.0"

--- a/packages/tabler-icons/package.json
+++ b/packages/tabler-icons/package.json
@@ -7,8 +7,8 @@
   },
   "homepage": "https://ng-icons.github.io/ng-icons/",
   "peerDependencies": {
-    "@angular/common": ">=12.0.0",
-    "@angular/core": ">=12.0.0"
+    "@angular/common": ">=12.0.0 <14.0.0",
+    "@angular/core": ">=12.0.0 <14.0.0"
   },
   "dependencies": {
     "tslib": "^2.2.0"

--- a/tools/generators/icon-library/utils/update-dependencies.ts
+++ b/tools/generators/icon-library/utils/update-dependencies.ts
@@ -9,8 +9,8 @@ export function updateDependencies(tree: Tree, schema: Schema) {
     };
     json.homepage = 'https://ng-icons.github.io/ng-icons/';
     json.peerDependencies = {
-      '@angular/common': '>=12.0.0',
-      '@angular/core': '>=12.0.0',
+      '@angular/common': '>=12.0.0 <14.0.0',
+      '@angular/core': '>=12.0.0 <14.0.0',
     };
     json.dependencies = {
       tslib: '^2.2.0',


### PR DESCRIPTION
When no units are defined in the size value chrome assumes a pixel value whereas firefox does not. This update coerces the value to a pixel value if no units are defined.

Fixes #16