### PR TITLE
Enable the icon component to take an svg as input

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,34 +141,34 @@ import { heroUsers } from '@ng-icons/heroicons/outline';
 export class AppComponent {}
 ```
 
-#### Passing icons to standalone child components
+#### Directly supplying an SVG
 
-When using standalone components, the icons need to be provided for each component.
-But if you want to pass an icon from a parent component to a child component, you can simply import the icon in the parent component and pass its svg to the child component.
-Use the `svg` attribute to set the icon.
+Should you need to supply an SVG directly set the `svg` input to the SVG string. This avoids the need to register the icon.
+Only icons from NG Icons iconsets will support the `color`, `size` and `strokeWidth` inputs.
 
 ```ts
 import { featherAirplay } from '@ng-icons/feather-icons';
 
+// parent.component.ts
 @Component({
   standalone: true,
-  template: '<app-child [icon]="icon">'
+  template: '<app-child [icon]="icon" />',
 })
 export class ParentComponent {
   icon = featherAirplay;
 }
-```
-```ts
+
+// child.component.ts
 import { NgIconComponent } from '@ng-icons/core';
 
 @Component({
   standalone: true,
   selector: 'app-child',
   imports: [NgIconComponent],
-  template: '<ng-icon [svg]="icon">'
+  template: '<ng-icon [svg]="icon" />',
 })
 export class ChildComponent {
-  @Input() icon = '';
+  @Input({ required: true }) icon!;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,37 @@ import { heroUsers } from '@ng-icons/heroicons/outline';
 export class AppComponent {}
 ```
 
+#### Passing icons to standalone child components
+
+When using standalone components, the icons need to be provided for each component.
+But if you want to pass an icon from a parent component to a child component, you can simply import the icon in the parent component and pass its svg to the child component.
+Use the `svg` attribute to set the icon.
+
+```ts
+import { featherAirplay } from '@ng-icons/feather-icons';
+
+@Component({
+  standalone: true,
+  template: '<app-child [icon]="icon">'
+})
+export class ParentComponent {
+  icon = featherAirplay;
+}
+```
+```ts
+import { NgIconComponent } from '@ng-icons/core';
+
+@Component({
+  standalone: true,
+  selector: 'app-child',
+  imports: [NgIconComponent],
+  template: '<ng-icon [svg]="icon">'
+})
+export class ChildComponent {
+  @Input() icon = '';
+}
+```
+
 ### Global Configuration
 
 You can configure the default size of icons by providing a `NgIconsConfig` object to the `provideNgIconsConfig`:

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "nx affected:test --all --parallel=8 --runInBand",
     "compile": "nx generate @ng-icons/workspace-plugin:svg-to-ts && nx run-many --target=build --all --parallel=8 && nx generate @ng-icons/workspace-plugin:update-readmes",
     "generate:iconsets": "nx generate @ng-icons/workspace-plugin:svg-to-ts",
-    "deploy": "nx run-many --all --target=deploy --parallel=8 --packageVersion=26.4.0"
+    "deploy": "nx run-many --all --target=deploy --parallel=8 --packageVersion=26.5.0"
   },
   "private": true,
   "dependencies": {

--- a/packages/akar-icons/README.md
+++ b/packages/akar-icons/README.md
@@ -141,6 +141,37 @@ import { heroUsers } from '@ng-icons/heroicons/outline';
 export class AppComponent {}
 ```
 
+#### Directly supplying an SVG
+
+Should you need to supply an SVG directly set the `svg` input to the SVG string. This avoids the need to register the icon.
+Only icons from NG Icons iconsets will support the `color`, `size` and `strokeWidth` inputs.
+
+```ts
+import { featherAirplay } from '@ng-icons/feather-icons';
+
+// parent.component.ts
+@Component({
+  standalone: true,
+  template: '<app-child [icon]="icon" />',
+})
+export class ParentComponent {
+  icon = featherAirplay;
+}
+
+// child.component.ts
+import { NgIconComponent } from '@ng-icons/core';
+
+@Component({
+  standalone: true,
+  selector: 'app-child',
+  imports: [NgIconComponent],
+  template: '<ng-icon [svg]="icon" />',
+})
+export class ChildComponent {
+  @Input({ required: true }) icon!;
+}
+```
+
 ### Global Configuration
 
 You can configure the default size of icons by providing a `NgIconsConfig` object to the `provideNgIconsConfig`:

--- a/packages/bootstrap-icons/README.md
+++ b/packages/bootstrap-icons/README.md
@@ -141,6 +141,37 @@ import { heroUsers } from '@ng-icons/heroicons/outline';
 export class AppComponent {}
 ```
 
+#### Directly supplying an SVG
+
+Should you need to supply an SVG directly set the `svg` input to the SVG string. This avoids the need to register the icon.
+Only icons from NG Icons iconsets will support the `color`, `size` and `strokeWidth` inputs.
+
+```ts
+import { featherAirplay } from '@ng-icons/feather-icons';
+
+// parent.component.ts
+@Component({
+  standalone: true,
+  template: '<app-child [icon]="icon" />',
+})
+export class ParentComponent {
+  icon = featherAirplay;
+}
+
+// child.component.ts
+import { NgIconComponent } from '@ng-icons/core';
+
+@Component({
+  standalone: true,
+  selector: 'app-child',
+  imports: [NgIconComponent],
+  template: '<ng-icon [svg]="icon" />',
+})
+export class ChildComponent {
+  @Input({ required: true }) icon!;
+}
+```
+
 ### Global Configuration
 
 You can configure the default size of icons by providing a `NgIconsConfig` object to the `provideNgIconsConfig`:

--- a/packages/circum-icons/README.md
+++ b/packages/circum-icons/README.md
@@ -141,6 +141,37 @@ import { heroUsers } from '@ng-icons/heroicons/outline';
 export class AppComponent {}
 ```
 
+#### Directly supplying an SVG
+
+Should you need to supply an SVG directly set the `svg` input to the SVG string. This avoids the need to register the icon.
+Only icons from NG Icons iconsets will support the `color`, `size` and `strokeWidth` inputs.
+
+```ts
+import { featherAirplay } from '@ng-icons/feather-icons';
+
+// parent.component.ts
+@Component({
+  standalone: true,
+  template: '<app-child [icon]="icon" />',
+})
+export class ParentComponent {
+  icon = featherAirplay;
+}
+
+// child.component.ts
+import { NgIconComponent } from '@ng-icons/core';
+
+@Component({
+  standalone: true,
+  selector: 'app-child',
+  imports: [NgIconComponent],
+  template: '<ng-icon [svg]="icon" />',
+})
+export class ChildComponent {
+  @Input({ required: true }) icon!;
+}
+```
+
 ### Global Configuration
 
 You can configure the default size of icons by providing a `NgIconsConfig` object to the `provideNgIconsConfig`:

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -141,6 +141,37 @@ import { heroUsers } from '@ng-icons/heroicons/outline';
 export class AppComponent {}
 ```
 
+#### Directly supplying an SVG
+
+Should you need to supply an SVG directly set the `svg` input to the SVG string. This avoids the need to register the icon.
+Only icons from NG Icons iconsets will support the `color`, `size` and `strokeWidth` inputs.
+
+```ts
+import { featherAirplay } from '@ng-icons/feather-icons';
+
+// parent.component.ts
+@Component({
+  standalone: true,
+  template: '<app-child [icon]="icon" />',
+})
+export class ParentComponent {
+  icon = featherAirplay;
+}
+
+// child.component.ts
+import { NgIconComponent } from '@ng-icons/core';
+
+@Component({
+  standalone: true,
+  selector: 'app-child',
+  imports: [NgIconComponent],
+  template: '<ng-icon [svg]="icon" />',
+})
+export class ChildComponent {
+  @Input({ required: true }) icon!;
+}
+```
+
 ### Global Configuration
 
 You can configure the default size of icons by providing a `NgIconsConfig` object to the `provideNgIconsConfig`:

--- a/packages/core/src/lib/components/icon/__snapshots__/icon.component.spec.ts.snap
+++ b/packages/core/src/lib/components/icon/__snapshots__/icon.component.spec.ts.snap
@@ -34,6 +34,40 @@ exports[`Icon should allow the icon to change 1`] = `
 </div>
 `;
 
+exports[`Icon should allow the icon to change by passing in a svg 1`] = `
+<div
+  id="root2"
+  style="--ng-icon__size: 1em;"
+>
+  <svg
+    class="feather feather-alert-triangle"
+    fill="none"
+    stroke="currentColor"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    style="width:var(--ng-icon__size, 1em);height:var(--ng-icon__size, 1em);stroke-width:var(--ng-icon__stroke-width, 2)"
+    viewBox="0 0 24 24"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"
+    />
+    <line
+      x1="12"
+      x2="12"
+      y1="9"
+      y2="13"
+    />
+    <line
+      x1="12"
+      x2="12.01"
+      y1="17"
+      y2="17"
+    />
+  </svg>
+</div>
+`;
+
 exports[`Icon should insert the expected template 1`] = `
 <div
   id="root0"

--- a/packages/core/src/lib/components/icon/icon.component.spec.ts
+++ b/packages/core/src/lib/components/icon/icon.component.spec.ts
@@ -50,18 +50,24 @@ describe('Icon', () => {
     fixture.detectChanges();
     expect(nativeElement).toMatchSnapshot();
   });
+
+  it('should allow the icon to change by passing in a svg', () => {
+    component.svg = featherAlertTriangle;
+    fixture.detectChanges();
+    expect(nativeElement).toMatchSnapshot();
+  });
 });
 
 @Component({
   template: `<ng-icon name="featherAlertCircle"></ng-icon>
     <router-outlet></router-outlet>`,
 })
-class RootComponent {}
+class RootComponent { }
 
 @Component({
   template: `<ng-icon name="featherAlertTriangle"></ng-icon>`,
 })
-class ChildComponent {}
+class ChildComponent { }
 
 @NgModule({
   imports: [
@@ -75,7 +81,7 @@ class ChildComponent {}
   ],
   declarations: [ChildComponent],
 })
-class ChildModule {}
+class ChildModule { }
 
 describe('Icon with multiple modules', () => {
   let fixture: ComponentFixture<RootComponent>;
@@ -121,7 +127,7 @@ describe('Icon with multiple modules', () => {
   imports: [NG_ICON_DIRECTIVES],
   providers: [provideIcons({ featherAlertCircle })],
 })
-class StandaloneComponent {}
+class StandaloneComponent { }
 
 describe('Standalone icon component', () => {
   let fixture: ComponentFixture<StandaloneComponent>;
@@ -160,7 +166,7 @@ describe('Standalone icon component', () => {
     }),
   ],
 })
-class LoaderComponent {}
+class LoaderComponent { }
 
 describe('Custom loader', () => {
   let fixture: ComponentFixture<LoaderComponent>;
@@ -184,7 +190,7 @@ describe('Custom loader', () => {
   template: '<ng-icon name="featherAlertCircle"></ng-icon>',
   imports: [NG_ICON_DIRECTIVES],
 })
-class CachedLoaderComponent {}
+class CachedLoaderComponent { }
 
 @Component({
   standalone: true,

--- a/packages/core/src/lib/components/icon/icon.component.ts
+++ b/packages/core/src/lib/components/icon/icon.component.ts
@@ -54,6 +54,11 @@ export class NgIcon {
     this.setIcon(name);
   }
 
+  /** Define the svg of the icon to display */
+  @Input() set svg(svg: string) {
+    this.setIconSVG(svg);
+  }
+
   /** Define the size of the icon */
   @HostBinding('style.--ng-icon__size')
   @Input({ transform: coerceCssPixelValue })
@@ -99,6 +104,16 @@ export class NgIcon {
     console.warn(
       `No icon named ${name} was found. You may need to import it using the withIcons function.`,
     );
+  }
+
+  /**
+   * Insert the given SVG into the template.
+   * @param svg The SVG to display.
+   */
+  private async setIconSVG(svg: string): Promise<void> {
+    // insert the SVG into the template
+    this.elementRef.nativeElement.innerHTML = svg;
+    return;
   }
 
   /**

--- a/packages/core/src/lib/components/icon/icon.component.ts
+++ b/packages/core/src/lib/components/icon/icon.component.ts
@@ -56,7 +56,7 @@ export class NgIcon {
 
   /** Define the svg of the icon to display */
   @Input() set svg(svg: string) {
-    this.setIconSVG(svg);
+    this.elementRef.nativeElement.innerHTML = svg;
   }
 
   /** Define the size of the icon */
@@ -104,16 +104,6 @@ export class NgIcon {
     console.warn(
       `No icon named ${name} was found. You may need to import it using the withIcons function.`,
     );
-  }
-
-  /**
-   * Insert the given SVG into the template.
-   * @param svg The SVG to display.
-   */
-  private async setIconSVG(svg: string): Promise<void> {
-    // insert the SVG into the template
-    this.elementRef.nativeElement.innerHTML = svg;
-    return;
   }
 
   /**

--- a/packages/cryptocurrency-icons/README.md
+++ b/packages/cryptocurrency-icons/README.md
@@ -141,6 +141,37 @@ import { heroUsers } from '@ng-icons/heroicons/outline';
 export class AppComponent {}
 ```
 
+#### Directly supplying an SVG
+
+Should you need to supply an SVG directly set the `svg` input to the SVG string. This avoids the need to register the icon.
+Only icons from NG Icons iconsets will support the `color`, `size` and `strokeWidth` inputs.
+
+```ts
+import { featherAirplay } from '@ng-icons/feather-icons';
+
+// parent.component.ts
+@Component({
+  standalone: true,
+  template: '<app-child [icon]="icon" />',
+})
+export class ParentComponent {
+  icon = featherAirplay;
+}
+
+// child.component.ts
+import { NgIconComponent } from '@ng-icons/core';
+
+@Component({
+  standalone: true,
+  selector: 'app-child',
+  imports: [NgIconComponent],
+  template: '<ng-icon [svg]="icon" />',
+})
+export class ChildComponent {
+  @Input({ required: true }) icon!;
+}
+```
+
 ### Global Configuration
 
 You can configure the default size of icons by providing a `NgIconsConfig` object to the `provideNgIconsConfig`:

--- a/packages/css-gg/README.md
+++ b/packages/css-gg/README.md
@@ -141,6 +141,37 @@ import { heroUsers } from '@ng-icons/heroicons/outline';
 export class AppComponent {}
 ```
 
+#### Directly supplying an SVG
+
+Should you need to supply an SVG directly set the `svg` input to the SVG string. This avoids the need to register the icon.
+Only icons from NG Icons iconsets will support the `color`, `size` and `strokeWidth` inputs.
+
+```ts
+import { featherAirplay } from '@ng-icons/feather-icons';
+
+// parent.component.ts
+@Component({
+  standalone: true,
+  template: '<app-child [icon]="icon" />',
+})
+export class ParentComponent {
+  icon = featherAirplay;
+}
+
+// child.component.ts
+import { NgIconComponent } from '@ng-icons/core';
+
+@Component({
+  standalone: true,
+  selector: 'app-child',
+  imports: [NgIconComponent],
+  template: '<ng-icon [svg]="icon" />',
+})
+export class ChildComponent {
+  @Input({ required: true }) icon!;
+}
+```
+
 ### Global Configuration
 
 You can configure the default size of icons by providing a `NgIconsConfig` object to the `provideNgIconsConfig`:

--- a/packages/dripicons/README.md
+++ b/packages/dripicons/README.md
@@ -141,6 +141,37 @@ import { heroUsers } from '@ng-icons/heroicons/outline';
 export class AppComponent {}
 ```
 
+#### Directly supplying an SVG
+
+Should you need to supply an SVG directly set the `svg` input to the SVG string. This avoids the need to register the icon.
+Only icons from NG Icons iconsets will support the `color`, `size` and `strokeWidth` inputs.
+
+```ts
+import { featherAirplay } from '@ng-icons/feather-icons';
+
+// parent.component.ts
+@Component({
+  standalone: true,
+  template: '<app-child [icon]="icon" />',
+})
+export class ParentComponent {
+  icon = featherAirplay;
+}
+
+// child.component.ts
+import { NgIconComponent } from '@ng-icons/core';
+
+@Component({
+  standalone: true,
+  selector: 'app-child',
+  imports: [NgIconComponent],
+  template: '<ng-icon [svg]="icon" />',
+})
+export class ChildComponent {
+  @Input({ required: true }) icon!;
+}
+```
+
 ### Global Configuration
 
 You can configure the default size of icons by providing a `NgIconsConfig` object to the `provideNgIconsConfig`:

--- a/packages/feather-icons/README.md
+++ b/packages/feather-icons/README.md
@@ -141,6 +141,37 @@ import { heroUsers } from '@ng-icons/heroicons/outline';
 export class AppComponent {}
 ```
 
+#### Directly supplying an SVG
+
+Should you need to supply an SVG directly set the `svg` input to the SVG string. This avoids the need to register the icon.
+Only icons from NG Icons iconsets will support the `color`, `size` and `strokeWidth` inputs.
+
+```ts
+import { featherAirplay } from '@ng-icons/feather-icons';
+
+// parent.component.ts
+@Component({
+  standalone: true,
+  template: '<app-child [icon]="icon" />',
+})
+export class ParentComponent {
+  icon = featherAirplay;
+}
+
+// child.component.ts
+import { NgIconComponent } from '@ng-icons/core';
+
+@Component({
+  standalone: true,
+  selector: 'app-child',
+  imports: [NgIconComponent],
+  template: '<ng-icon [svg]="icon" />',
+})
+export class ChildComponent {
+  @Input({ required: true }) icon!;
+}
+```
+
 ### Global Configuration
 
 You can configure the default size of icons by providing a `NgIconsConfig` object to the `provideNgIconsConfig`:

--- a/packages/font-awesome/README.md
+++ b/packages/font-awesome/README.md
@@ -141,6 +141,37 @@ import { heroUsers } from '@ng-icons/heroicons/outline';
 export class AppComponent {}
 ```
 
+#### Directly supplying an SVG
+
+Should you need to supply an SVG directly set the `svg` input to the SVG string. This avoids the need to register the icon.
+Only icons from NG Icons iconsets will support the `color`, `size` and `strokeWidth` inputs.
+
+```ts
+import { featherAirplay } from '@ng-icons/feather-icons';
+
+// parent.component.ts
+@Component({
+  standalone: true,
+  template: '<app-child [icon]="icon" />',
+})
+export class ParentComponent {
+  icon = featherAirplay;
+}
+
+// child.component.ts
+import { NgIconComponent } from '@ng-icons/core';
+
+@Component({
+  standalone: true,
+  selector: 'app-child',
+  imports: [NgIconComponent],
+  template: '<ng-icon [svg]="icon" />',
+})
+export class ChildComponent {
+  @Input({ required: true }) icon!;
+}
+```
+
 ### Global Configuration
 
 You can configure the default size of icons by providing a `NgIconsConfig` object to the `provideNgIconsConfig`:

--- a/packages/heroicons/README.md
+++ b/packages/heroicons/README.md
@@ -141,6 +141,37 @@ import { heroUsers } from '@ng-icons/heroicons/outline';
 export class AppComponent {}
 ```
 
+#### Directly supplying an SVG
+
+Should you need to supply an SVG directly set the `svg` input to the SVG string. This avoids the need to register the icon.
+Only icons from NG Icons iconsets will support the `color`, `size` and `strokeWidth` inputs.
+
+```ts
+import { featherAirplay } from '@ng-icons/feather-icons';
+
+// parent.component.ts
+@Component({
+  standalone: true,
+  template: '<app-child [icon]="icon" />',
+})
+export class ParentComponent {
+  icon = featherAirplay;
+}
+
+// child.component.ts
+import { NgIconComponent } from '@ng-icons/core';
+
+@Component({
+  standalone: true,
+  selector: 'app-child',
+  imports: [NgIconComponent],
+  template: '<ng-icon [svg]="icon" />',
+})
+export class ChildComponent {
+  @Input({ required: true }) icon!;
+}
+```
+
 ### Global Configuration
 
 You can configure the default size of icons by providing a `NgIconsConfig` object to the `provideNgIconsConfig`:

--- a/packages/iconoir/README.md
+++ b/packages/iconoir/README.md
@@ -141,6 +141,37 @@ import { heroUsers } from '@ng-icons/heroicons/outline';
 export class AppComponent {}
 ```
 
+#### Directly supplying an SVG
+
+Should you need to supply an SVG directly set the `svg` input to the SVG string. This avoids the need to register the icon.
+Only icons from NG Icons iconsets will support the `color`, `size` and `strokeWidth` inputs.
+
+```ts
+import { featherAirplay } from '@ng-icons/feather-icons';
+
+// parent.component.ts
+@Component({
+  standalone: true,
+  template: '<app-child [icon]="icon" />',
+})
+export class ParentComponent {
+  icon = featherAirplay;
+}
+
+// child.component.ts
+import { NgIconComponent } from '@ng-icons/core';
+
+@Component({
+  standalone: true,
+  selector: 'app-child',
+  imports: [NgIconComponent],
+  template: '<ng-icon [svg]="icon" />',
+})
+export class ChildComponent {
+  @Input({ required: true }) icon!;
+}
+```
+
 ### Global Configuration
 
 You can configure the default size of icons by providing a `NgIconsConfig` object to the `provideNgIconsConfig`:

--- a/packages/iconsax/README.md
+++ b/packages/iconsax/README.md
@@ -141,6 +141,37 @@ import { heroUsers } from '@ng-icons/heroicons/outline';
 export class AppComponent {}
 ```
 
+#### Directly supplying an SVG
+
+Should you need to supply an SVG directly set the `svg` input to the SVG string. This avoids the need to register the icon.
+Only icons from NG Icons iconsets will support the `color`, `size` and `strokeWidth` inputs.
+
+```ts
+import { featherAirplay } from '@ng-icons/feather-icons';
+
+// parent.component.ts
+@Component({
+  standalone: true,
+  template: '<app-child [icon]="icon" />',
+})
+export class ParentComponent {
+  icon = featherAirplay;
+}
+
+// child.component.ts
+import { NgIconComponent } from '@ng-icons/core';
+
+@Component({
+  standalone: true,
+  selector: 'app-child',
+  imports: [NgIconComponent],
+  template: '<ng-icon [svg]="icon" />',
+})
+export class ChildComponent {
+  @Input({ required: true }) icon!;
+}
+```
+
 ### Global Configuration
 
 You can configure the default size of icons by providing a `NgIconsConfig` object to the `provideNgIconsConfig`:

--- a/packages/ionicons/README.md
+++ b/packages/ionicons/README.md
@@ -141,6 +141,37 @@ import { heroUsers } from '@ng-icons/heroicons/outline';
 export class AppComponent {}
 ```
 
+#### Directly supplying an SVG
+
+Should you need to supply an SVG directly set the `svg` input to the SVG string. This avoids the need to register the icon.
+Only icons from NG Icons iconsets will support the `color`, `size` and `strokeWidth` inputs.
+
+```ts
+import { featherAirplay } from '@ng-icons/feather-icons';
+
+// parent.component.ts
+@Component({
+  standalone: true,
+  template: '<app-child [icon]="icon" />',
+})
+export class ParentComponent {
+  icon = featherAirplay;
+}
+
+// child.component.ts
+import { NgIconComponent } from '@ng-icons/core';
+
+@Component({
+  standalone: true,
+  selector: 'app-child',
+  imports: [NgIconComponent],
+  template: '<ng-icon [svg]="icon" />',
+})
+export class ChildComponent {
+  @Input({ required: true }) icon!;
+}
+```
+
 ### Global Configuration
 
 You can configure the default size of icons by providing a `NgIconsConfig` object to the `provideNgIconsConfig`:

--- a/packages/jam-icons/README.md
+++ b/packages/jam-icons/README.md
@@ -141,6 +141,37 @@ import { heroUsers } from '@ng-icons/heroicons/outline';
 export class AppComponent {}
 ```
 
+#### Directly supplying an SVG
+
+Should you need to supply an SVG directly set the `svg` input to the SVG string. This avoids the need to register the icon.
+Only icons from NG Icons iconsets will support the `color`, `size` and `strokeWidth` inputs.
+
+```ts
+import { featherAirplay } from '@ng-icons/feather-icons';
+
+// parent.component.ts
+@Component({
+  standalone: true,
+  template: '<app-child [icon]="icon" />',
+})
+export class ParentComponent {
+  icon = featherAirplay;
+}
+
+// child.component.ts
+import { NgIconComponent } from '@ng-icons/core';
+
+@Component({
+  standalone: true,
+  selector: 'app-child',
+  imports: [NgIconComponent],
+  template: '<ng-icon [svg]="icon" />',
+})
+export class ChildComponent {
+  @Input({ required: true }) icon!;
+}
+```
+
 ### Global Configuration
 
 You can configure the default size of icons by providing a `NgIconsConfig` object to the `provideNgIconsConfig`:

--- a/packages/lucide/README.md
+++ b/packages/lucide/README.md
@@ -141,6 +141,37 @@ import { heroUsers } from '@ng-icons/heroicons/outline';
 export class AppComponent {}
 ```
 
+#### Directly supplying an SVG
+
+Should you need to supply an SVG directly set the `svg` input to the SVG string. This avoids the need to register the icon.
+Only icons from NG Icons iconsets will support the `color`, `size` and `strokeWidth` inputs.
+
+```ts
+import { featherAirplay } from '@ng-icons/feather-icons';
+
+// parent.component.ts
+@Component({
+  standalone: true,
+  template: '<app-child [icon]="icon" />',
+})
+export class ParentComponent {
+  icon = featherAirplay;
+}
+
+// child.component.ts
+import { NgIconComponent } from '@ng-icons/core';
+
+@Component({
+  standalone: true,
+  selector: 'app-child',
+  imports: [NgIconComponent],
+  template: '<ng-icon [svg]="icon" />',
+})
+export class ChildComponent {
+  @Input({ required: true }) icon!;
+}
+```
+
 ### Global Configuration
 
 You can configure the default size of icons by providing a `NgIconsConfig` object to the `provideNgIconsConfig`:

--- a/packages/material-file-icons/README.md
+++ b/packages/material-file-icons/README.md
@@ -141,6 +141,37 @@ import { heroUsers } from '@ng-icons/heroicons/outline';
 export class AppComponent {}
 ```
 
+#### Directly supplying an SVG
+
+Should you need to supply an SVG directly set the `svg` input to the SVG string. This avoids the need to register the icon.
+Only icons from NG Icons iconsets will support the `color`, `size` and `strokeWidth` inputs.
+
+```ts
+import { featherAirplay } from '@ng-icons/feather-icons';
+
+// parent.component.ts
+@Component({
+  standalone: true,
+  template: '<app-child [icon]="icon" />',
+})
+export class ParentComponent {
+  icon = featherAirplay;
+}
+
+// child.component.ts
+import { NgIconComponent } from '@ng-icons/core';
+
+@Component({
+  standalone: true,
+  selector: 'app-child',
+  imports: [NgIconComponent],
+  template: '<ng-icon [svg]="icon" />',
+})
+export class ChildComponent {
+  @Input({ required: true }) icon!;
+}
+```
+
 ### Global Configuration
 
 You can configure the default size of icons by providing a `NgIconsConfig` object to the `provideNgIconsConfig`:

--- a/packages/material-icons/README.md
+++ b/packages/material-icons/README.md
@@ -141,6 +141,37 @@ import { heroUsers } from '@ng-icons/heroicons/outline';
 export class AppComponent {}
 ```
 
+#### Directly supplying an SVG
+
+Should you need to supply an SVG directly set the `svg` input to the SVG string. This avoids the need to register the icon.
+Only icons from NG Icons iconsets will support the `color`, `size` and `strokeWidth` inputs.
+
+```ts
+import { featherAirplay } from '@ng-icons/feather-icons';
+
+// parent.component.ts
+@Component({
+  standalone: true,
+  template: '<app-child [icon]="icon" />',
+})
+export class ParentComponent {
+  icon = featherAirplay;
+}
+
+// child.component.ts
+import { NgIconComponent } from '@ng-icons/core';
+
+@Component({
+  standalone: true,
+  selector: 'app-child',
+  imports: [NgIconComponent],
+  template: '<ng-icon [svg]="icon" />',
+})
+export class ChildComponent {
+  @Input({ required: true }) icon!;
+}
+```
+
 ### Global Configuration
 
 You can configure the default size of icons by providing a `NgIconsConfig` object to the `provideNgIconsConfig`:

--- a/packages/material-symbols/README.md
+++ b/packages/material-symbols/README.md
@@ -141,6 +141,37 @@ import { heroUsers } from '@ng-icons/heroicons/outline';
 export class AppComponent {}
 ```
 
+#### Directly supplying an SVG
+
+Should you need to supply an SVG directly set the `svg` input to the SVG string. This avoids the need to register the icon.
+Only icons from NG Icons iconsets will support the `color`, `size` and `strokeWidth` inputs.
+
+```ts
+import { featherAirplay } from '@ng-icons/feather-icons';
+
+// parent.component.ts
+@Component({
+  standalone: true,
+  template: '<app-child [icon]="icon" />',
+})
+export class ParentComponent {
+  icon = featherAirplay;
+}
+
+// child.component.ts
+import { NgIconComponent } from '@ng-icons/core';
+
+@Component({
+  standalone: true,
+  selector: 'app-child',
+  imports: [NgIconComponent],
+  template: '<ng-icon [svg]="icon" />',
+})
+export class ChildComponent {
+  @Input({ required: true }) icon!;
+}
+```
+
 ### Global Configuration
 
 You can configure the default size of icons by providing a `NgIconsConfig` object to the `provideNgIconsConfig`:

--- a/packages/octicons/README.md
+++ b/packages/octicons/README.md
@@ -141,6 +141,37 @@ import { heroUsers } from '@ng-icons/heroicons/outline';
 export class AppComponent {}
 ```
 
+#### Directly supplying an SVG
+
+Should you need to supply an SVG directly set the `svg` input to the SVG string. This avoids the need to register the icon.
+Only icons from NG Icons iconsets will support the `color`, `size` and `strokeWidth` inputs.
+
+```ts
+import { featherAirplay } from '@ng-icons/feather-icons';
+
+// parent.component.ts
+@Component({
+  standalone: true,
+  template: '<app-child [icon]="icon" />',
+})
+export class ParentComponent {
+  icon = featherAirplay;
+}
+
+// child.component.ts
+import { NgIconComponent } from '@ng-icons/core';
+
+@Component({
+  standalone: true,
+  selector: 'app-child',
+  imports: [NgIconComponent],
+  template: '<ng-icon [svg]="icon" />',
+})
+export class ChildComponent {
+  @Input({ required: true }) icon!;
+}
+```
+
 ### Global Configuration
 
 You can configure the default size of icons by providing a `NgIconsConfig` object to the `provideNgIconsConfig`:

--- a/packages/radix-icons/README.md
+++ b/packages/radix-icons/README.md
@@ -141,6 +141,37 @@ import { heroUsers } from '@ng-icons/heroicons/outline';
 export class AppComponent {}
 ```
 
+#### Directly supplying an SVG
+
+Should you need to supply an SVG directly set the `svg` input to the SVG string. This avoids the need to register the icon.
+Only icons from NG Icons iconsets will support the `color`, `size` and `strokeWidth` inputs.
+
+```ts
+import { featherAirplay } from '@ng-icons/feather-icons';
+
+// parent.component.ts
+@Component({
+  standalone: true,
+  template: '<app-child [icon]="icon" />',
+})
+export class ParentComponent {
+  icon = featherAirplay;
+}
+
+// child.component.ts
+import { NgIconComponent } from '@ng-icons/core';
+
+@Component({
+  standalone: true,
+  selector: 'app-child',
+  imports: [NgIconComponent],
+  template: '<ng-icon [svg]="icon" />',
+})
+export class ChildComponent {
+  @Input({ required: true }) icon!;
+}
+```
+
 ### Global Configuration
 
 You can configure the default size of icons by providing a `NgIconsConfig` object to the `provideNgIconsConfig`:

--- a/packages/remixicon/README.md
+++ b/packages/remixicon/README.md
@@ -141,6 +141,37 @@ import { heroUsers } from '@ng-icons/heroicons/outline';
 export class AppComponent {}
 ```
 
+#### Directly supplying an SVG
+
+Should you need to supply an SVG directly set the `svg` input to the SVG string. This avoids the need to register the icon.
+Only icons from NG Icons iconsets will support the `color`, `size` and `strokeWidth` inputs.
+
+```ts
+import { featherAirplay } from '@ng-icons/feather-icons';
+
+// parent.component.ts
+@Component({
+  standalone: true,
+  template: '<app-child [icon]="icon" />',
+})
+export class ParentComponent {
+  icon = featherAirplay;
+}
+
+// child.component.ts
+import { NgIconComponent } from '@ng-icons/core';
+
+@Component({
+  standalone: true,
+  selector: 'app-child',
+  imports: [NgIconComponent],
+  template: '<ng-icon [svg]="icon" />',
+})
+export class ChildComponent {
+  @Input({ required: true }) icon!;
+}
+```
+
 ### Global Configuration
 
 You can configure the default size of icons by providing a `NgIconsConfig` object to the `provideNgIconsConfig`:

--- a/packages/schematics/README.md
+++ b/packages/schematics/README.md
@@ -141,6 +141,37 @@ import { heroUsers } from '@ng-icons/heroicons/outline';
 export class AppComponent {}
 ```
 
+#### Directly supplying an SVG
+
+Should you need to supply an SVG directly set the `svg` input to the SVG string. This avoids the need to register the icon.
+Only icons from NG Icons iconsets will support the `color`, `size` and `strokeWidth` inputs.
+
+```ts
+import { featherAirplay } from '@ng-icons/feather-icons';
+
+// parent.component.ts
+@Component({
+  standalone: true,
+  template: '<app-child [icon]="icon" />',
+})
+export class ParentComponent {
+  icon = featherAirplay;
+}
+
+// child.component.ts
+import { NgIconComponent } from '@ng-icons/core';
+
+@Component({
+  standalone: true,
+  selector: 'app-child',
+  imports: [NgIconComponent],
+  template: '<ng-icon [svg]="icon" />',
+})
+export class ChildComponent {
+  @Input({ required: true }) icon!;
+}
+```
+
 ### Global Configuration
 
 You can configure the default size of icons by providing a `NgIconsConfig` object to the `provideNgIconsConfig`:

--- a/packages/simple-icons/README.md
+++ b/packages/simple-icons/README.md
@@ -141,6 +141,37 @@ import { heroUsers } from '@ng-icons/heroicons/outline';
 export class AppComponent {}
 ```
 
+#### Directly supplying an SVG
+
+Should you need to supply an SVG directly set the `svg` input to the SVG string. This avoids the need to register the icon.
+Only icons from NG Icons iconsets will support the `color`, `size` and `strokeWidth` inputs.
+
+```ts
+import { featherAirplay } from '@ng-icons/feather-icons';
+
+// parent.component.ts
+@Component({
+  standalone: true,
+  template: '<app-child [icon]="icon" />',
+})
+export class ParentComponent {
+  icon = featherAirplay;
+}
+
+// child.component.ts
+import { NgIconComponent } from '@ng-icons/core';
+
+@Component({
+  standalone: true,
+  selector: 'app-child',
+  imports: [NgIconComponent],
+  template: '<ng-icon [svg]="icon" />',
+})
+export class ChildComponent {
+  @Input({ required: true }) icon!;
+}
+```
+
 ### Global Configuration
 
 You can configure the default size of icons by providing a `NgIconsConfig` object to the `provideNgIconsConfig`:

--- a/packages/tabler-icons/README.md
+++ b/packages/tabler-icons/README.md
@@ -141,6 +141,37 @@ import { heroUsers } from '@ng-icons/heroicons/outline';
 export class AppComponent {}
 ```
 
+#### Directly supplying an SVG
+
+Should you need to supply an SVG directly set the `svg` input to the SVG string. This avoids the need to register the icon.
+Only icons from NG Icons iconsets will support the `color`, `size` and `strokeWidth` inputs.
+
+```ts
+import { featherAirplay } from '@ng-icons/feather-icons';
+
+// parent.component.ts
+@Component({
+  standalone: true,
+  template: '<app-child [icon]="icon" />',
+})
+export class ParentComponent {
+  icon = featherAirplay;
+}
+
+// child.component.ts
+import { NgIconComponent } from '@ng-icons/core';
+
+@Component({
+  standalone: true,
+  selector: 'app-child',
+  imports: [NgIconComponent],
+  template: '<ng-icon [svg]="icon" />',
+})
+export class ChildComponent {
+  @Input({ required: true }) icon!;
+}
+```
+
 ### Global Configuration
 
 You can configure the default size of icons by providing a `NgIconsConfig` object to the `provideNgIconsConfig`:

--- a/packages/typicons/README.md
+++ b/packages/typicons/README.md
@@ -141,6 +141,37 @@ import { heroUsers } from '@ng-icons/heroicons/outline';
 export class AppComponent {}
 ```
 
+#### Directly supplying an SVG
+
+Should you need to supply an SVG directly set the `svg` input to the SVG string. This avoids the need to register the icon.
+Only icons from NG Icons iconsets will support the `color`, `size` and `strokeWidth` inputs.
+
+```ts
+import { featherAirplay } from '@ng-icons/feather-icons';
+
+// parent.component.ts
+@Component({
+  standalone: true,
+  template: '<app-child [icon]="icon" />',
+})
+export class ParentComponent {
+  icon = featherAirplay;
+}
+
+// child.component.ts
+import { NgIconComponent } from '@ng-icons/core';
+
+@Component({
+  standalone: true,
+  selector: 'app-child',
+  imports: [NgIconComponent],
+  template: '<ng-icon [svg]="icon" />',
+})
+export class ChildComponent {
+  @Input({ required: true }) icon!;
+}
+```
+
 ### Global Configuration
 
 You can configure the default size of icons by providing a `NgIconsConfig` object to the `provideNgIconsConfig`:

--- a/packages/ux-aspects/README.md
+++ b/packages/ux-aspects/README.md
@@ -141,6 +141,37 @@ import { heroUsers } from '@ng-icons/heroicons/outline';
 export class AppComponent {}
 ```
 
+#### Directly supplying an SVG
+
+Should you need to supply an SVG directly set the `svg` input to the SVG string. This avoids the need to register the icon.
+Only icons from NG Icons iconsets will support the `color`, `size` and `strokeWidth` inputs.
+
+```ts
+import { featherAirplay } from '@ng-icons/feather-icons';
+
+// parent.component.ts
+@Component({
+  standalone: true,
+  template: '<app-child [icon]="icon" />',
+})
+export class ParentComponent {
+  icon = featherAirplay;
+}
+
+// child.component.ts
+import { NgIconComponent } from '@ng-icons/core';
+
+@Component({
+  standalone: true,
+  selector: 'app-child',
+  imports: [NgIconComponent],
+  template: '<ng-icon [svg]="icon" />',
+})
+export class ChildComponent {
+  @Input({ required: true }) icon!;
+}
+```
+
 ### Global Configuration
 
 You can configure the default size of icons by providing a `NgIconsConfig` object to the `provideNgIconsConfig`:

--- a/tools/workspace-plugin/README.md
+++ b/tools/workspace-plugin/README.md
@@ -141,6 +141,37 @@ import { heroUsers } from '@ng-icons/heroicons/outline';
 export class AppComponent {}
 ```
 
+#### Directly supplying an SVG
+
+Should you need to supply an SVG directly set the `svg` input to the SVG string. This avoids the need to register the icon.
+Only icons from NG Icons iconsets will support the `color`, `size` and `strokeWidth` inputs.
+
+```ts
+import { featherAirplay } from '@ng-icons/feather-icons';
+
+// parent.component.ts
+@Component({
+  standalone: true,
+  template: '<app-child [icon]="icon" />',
+})
+export class ParentComponent {
+  icon = featherAirplay;
+}
+
+// child.component.ts
+import { NgIconComponent } from '@ng-icons/core';
+
+@Component({
+  standalone: true,
+  selector: 'app-child',
+  imports: [NgIconComponent],
+  template: '<ng-icon [svg]="icon" />',
+})
+export class ChildComponent {
+  @Input({ required: true }) icon!;
+}
+```
+
 ### Global Configuration
 
 You can configure the default size of icons by providing a `NgIconsConfig` object to the `provideNgIconsConfig`:


### PR DESCRIPTION
When using standalone components, we need to provide the icons in each component. Sometimes we need to pass an icon from one component to another component, without knowing which icons to load beforehand AND without being able to use a dynamic loader.

Example:
I have a modal service taking a config. In the config I can define an icon to be display in the modals header. It is impossible to know, which icons the modal component needs to load AND loading the icons dynamically is not possible in my case.

Solution:
Enable the icon component to take either the name of the icon (which than gets loaded) or the svg of the icon directly. Therefor I can load the icon in one component and can pass it to any other component.