### PR TITLE
docs(ng-icons): update responseType in custom SVG loader example

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ bootstrapApplication(AppComponent, {
   providers: [
     provideNgIconLoader(name => {
       const http = inject(HttpClient);
-      return http.get(`/assets/icons/${name}.svg`);
+      return http.get(`/assets/icons/${name}.svg`, { responseType: 'text' });
     }),
   ],
 });

--- a/packages/akar-icons/README.md
+++ b/packages/akar-icons/README.md
@@ -219,7 +219,7 @@ bootstrapApplication(AppComponent, {
   providers: [
     provideNgIconLoader(name => {
       const http = inject(HttpClient);
-      return http.get(`/assets/icons/${name}.svg`);
+      return http.get(`/assets/icons/${name}.svg`, { responseType: 'text' });
     }),
   ],
 });

--- a/packages/bootstrap-icons/README.md
+++ b/packages/bootstrap-icons/README.md
@@ -219,7 +219,7 @@ bootstrapApplication(AppComponent, {
   providers: [
     provideNgIconLoader(name => {
       const http = inject(HttpClient);
-      return http.get(`/assets/icons/${name}.svg`);
+      return http.get(`/assets/icons/${name}.svg`, { responseType: 'text' });
     }),
   ],
 });

--- a/packages/circum-icons/README.md
+++ b/packages/circum-icons/README.md
@@ -219,7 +219,7 @@ bootstrapApplication(AppComponent, {
   providers: [
     provideNgIconLoader(name => {
       const http = inject(HttpClient);
-      return http.get(`/assets/icons/${name}.svg`);
+      return http.get(`/assets/icons/${name}.svg`, { responseType: 'text' });
     }),
   ],
 });

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -219,7 +219,7 @@ bootstrapApplication(AppComponent, {
   providers: [
     provideNgIconLoader(name => {
       const http = inject(HttpClient);
-      return http.get(`/assets/icons/${name}.svg`);
+      return http.get(`/assets/icons/${name}.svg`, { responseType: 'text' });
     }),
   ],
 });

--- a/packages/cryptocurrency-icons/README.md
+++ b/packages/cryptocurrency-icons/README.md
@@ -219,7 +219,7 @@ bootstrapApplication(AppComponent, {
   providers: [
     provideNgIconLoader(name => {
       const http = inject(HttpClient);
-      return http.get(`/assets/icons/${name}.svg`);
+      return http.get(`/assets/icons/${name}.svg`, { responseType: 'text' });
     }),
   ],
 });

--- a/packages/css-gg/README.md
+++ b/packages/css-gg/README.md
@@ -219,7 +219,7 @@ bootstrapApplication(AppComponent, {
   providers: [
     provideNgIconLoader(name => {
       const http = inject(HttpClient);
-      return http.get(`/assets/icons/${name}.svg`);
+      return http.get(`/assets/icons/${name}.svg`, { responseType: 'text' });
     }),
   ],
 });

--- a/packages/dripicons/README.md
+++ b/packages/dripicons/README.md
@@ -219,7 +219,7 @@ bootstrapApplication(AppComponent, {
   providers: [
     provideNgIconLoader(name => {
       const http = inject(HttpClient);
-      return http.get(`/assets/icons/${name}.svg`);
+      return http.get(`/assets/icons/${name}.svg`, { responseType: 'text' });
     }),
   ],
 });

--- a/packages/feather-icons/README.md
+++ b/packages/feather-icons/README.md
@@ -219,7 +219,7 @@ bootstrapApplication(AppComponent, {
   providers: [
     provideNgIconLoader(name => {
       const http = inject(HttpClient);
-      return http.get(`/assets/icons/${name}.svg`);
+      return http.get(`/assets/icons/${name}.svg`, { responseType: 'text' });
     }),
   ],
 });

--- a/packages/font-awesome/README.md
+++ b/packages/font-awesome/README.md
@@ -219,7 +219,7 @@ bootstrapApplication(AppComponent, {
   providers: [
     provideNgIconLoader(name => {
       const http = inject(HttpClient);
-      return http.get(`/assets/icons/${name}.svg`);
+      return http.get(`/assets/icons/${name}.svg`, { responseType: 'text' });
     }),
   ],
 });

--- a/packages/heroicons/README.md
+++ b/packages/heroicons/README.md
@@ -219,7 +219,7 @@ bootstrapApplication(AppComponent, {
   providers: [
     provideNgIconLoader(name => {
       const http = inject(HttpClient);
-      return http.get(`/assets/icons/${name}.svg`);
+      return http.get(`/assets/icons/${name}.svg`, { responseType: 'text' });
     }),
   ],
 });

--- a/packages/iconoir/README.md
+++ b/packages/iconoir/README.md
@@ -219,7 +219,7 @@ bootstrapApplication(AppComponent, {
   providers: [
     provideNgIconLoader(name => {
       const http = inject(HttpClient);
-      return http.get(`/assets/icons/${name}.svg`);
+      return http.get(`/assets/icons/${name}.svg`, { responseType: 'text' });
     }),
   ],
 });

--- a/packages/iconsax/README.md
+++ b/packages/iconsax/README.md
@@ -219,7 +219,7 @@ bootstrapApplication(AppComponent, {
   providers: [
     provideNgIconLoader(name => {
       const http = inject(HttpClient);
-      return http.get(`/assets/icons/${name}.svg`);
+      return http.get(`/assets/icons/${name}.svg`, { responseType: 'text' });
     }),
   ],
 });

--- a/packages/ionicons/README.md
+++ b/packages/ionicons/README.md
@@ -219,7 +219,7 @@ bootstrapApplication(AppComponent, {
   providers: [
     provideNgIconLoader(name => {
       const http = inject(HttpClient);
-      return http.get(`/assets/icons/${name}.svg`);
+      return http.get(`/assets/icons/${name}.svg`, { responseType: 'text' });
     }),
   ],
 });

--- a/packages/jam-icons/README.md
+++ b/packages/jam-icons/README.md
@@ -219,7 +219,7 @@ bootstrapApplication(AppComponent, {
   providers: [
     provideNgIconLoader(name => {
       const http = inject(HttpClient);
-      return http.get(`/assets/icons/${name}.svg`);
+      return http.get(`/assets/icons/${name}.svg`, { responseType: 'text' });
     }),
   ],
 });

--- a/packages/lucide/README.md
+++ b/packages/lucide/README.md
@@ -219,7 +219,7 @@ bootstrapApplication(AppComponent, {
   providers: [
     provideNgIconLoader(name => {
       const http = inject(HttpClient);
-      return http.get(`/assets/icons/${name}.svg`);
+      return http.get(`/assets/icons/${name}.svg`, { responseType: 'text' });
     }),
   ],
 });

--- a/packages/material-file-icons/README.md
+++ b/packages/material-file-icons/README.md
@@ -219,7 +219,7 @@ bootstrapApplication(AppComponent, {
   providers: [
     provideNgIconLoader(name => {
       const http = inject(HttpClient);
-      return http.get(`/assets/icons/${name}.svg`);
+      return http.get(`/assets/icons/${name}.svg`, { responseType: 'text' });
     }),
   ],
 });

--- a/packages/material-icons/README.md
+++ b/packages/material-icons/README.md
@@ -219,7 +219,7 @@ bootstrapApplication(AppComponent, {
   providers: [
     provideNgIconLoader(name => {
       const http = inject(HttpClient);
-      return http.get(`/assets/icons/${name}.svg`);
+      return http.get(`/assets/icons/${name}.svg`, { responseType: 'text' });
     }),
   ],
 });

--- a/packages/material-symbols/README.md
+++ b/packages/material-symbols/README.md
@@ -219,7 +219,7 @@ bootstrapApplication(AppComponent, {
   providers: [
     provideNgIconLoader(name => {
       const http = inject(HttpClient);
-      return http.get(`/assets/icons/${name}.svg`);
+      return http.get(`/assets/icons/${name}.svg`, { responseType: 'text' });
     }),
   ],
 });

--- a/packages/octicons/README.md
+++ b/packages/octicons/README.md
@@ -219,7 +219,7 @@ bootstrapApplication(AppComponent, {
   providers: [
     provideNgIconLoader(name => {
       const http = inject(HttpClient);
-      return http.get(`/assets/icons/${name}.svg`);
+      return http.get(`/assets/icons/${name}.svg`, { responseType: 'text' });
     }),
   ],
 });

--- a/packages/radix-icons/README.md
+++ b/packages/radix-icons/README.md
@@ -219,7 +219,7 @@ bootstrapApplication(AppComponent, {
   providers: [
     provideNgIconLoader(name => {
       const http = inject(HttpClient);
-      return http.get(`/assets/icons/${name}.svg`);
+      return http.get(`/assets/icons/${name}.svg`, { responseType: 'text' });
     }),
   ],
 });

--- a/packages/remixicon/README.md
+++ b/packages/remixicon/README.md
@@ -219,7 +219,7 @@ bootstrapApplication(AppComponent, {
   providers: [
     provideNgIconLoader(name => {
       const http = inject(HttpClient);
-      return http.get(`/assets/icons/${name}.svg`);
+      return http.get(`/assets/icons/${name}.svg`, { responseType: 'text' });
     }),
   ],
 });

--- a/packages/schematics/README.md
+++ b/packages/schematics/README.md
@@ -219,7 +219,7 @@ bootstrapApplication(AppComponent, {
   providers: [
     provideNgIconLoader(name => {
       const http = inject(HttpClient);
-      return http.get(`/assets/icons/${name}.svg`);
+      return http.get(`/assets/icons/${name}.svg`, { responseType: 'text' });
     }),
   ],
 });

--- a/packages/simple-icons/README.md
+++ b/packages/simple-icons/README.md
@@ -219,7 +219,7 @@ bootstrapApplication(AppComponent, {
   providers: [
     provideNgIconLoader(name => {
       const http = inject(HttpClient);
-      return http.get(`/assets/icons/${name}.svg`);
+      return http.get(`/assets/icons/${name}.svg`, { responseType: 'text' });
     }),
   ],
 });

--- a/packages/tabler-icons/README.md
+++ b/packages/tabler-icons/README.md
@@ -219,7 +219,7 @@ bootstrapApplication(AppComponent, {
   providers: [
     provideNgIconLoader(name => {
       const http = inject(HttpClient);
-      return http.get(`/assets/icons/${name}.svg`);
+      return http.get(`/assets/icons/${name}.svg`, { responseType: 'text' });
     }),
   ],
 });

--- a/packages/typicons/README.md
+++ b/packages/typicons/README.md
@@ -219,7 +219,7 @@ bootstrapApplication(AppComponent, {
   providers: [
     provideNgIconLoader(name => {
       const http = inject(HttpClient);
-      return http.get(`/assets/icons/${name}.svg`);
+      return http.get(`/assets/icons/${name}.svg`, { responseType: 'text' });
     }),
   ],
 });

--- a/packages/ux-aspects/README.md
+++ b/packages/ux-aspects/README.md
@@ -219,7 +219,7 @@ bootstrapApplication(AppComponent, {
   providers: [
     provideNgIconLoader(name => {
       const http = inject(HttpClient);
-      return http.get(`/assets/icons/${name}.svg`);
+      return http.get(`/assets/icons/${name}.svg`, { responseType: 'text' });
     }),
   ],
 });

--- a/tools/workspace-plugin/README.md
+++ b/tools/workspace-plugin/README.md
@@ -219,7 +219,7 @@ bootstrapApplication(AppComponent, {
   providers: [
     provideNgIconLoader(name => {
       const http = inject(HttpClient);
-      return http.get(`/assets/icons/${name}.svg`);
+      return http.get(`/assets/icons/${name}.svg`, { responseType: 'text' });
     }),
   ],
 });


### PR DESCRIPTION
This pull request updates the documentation for the `provideNgIconLoader` usage example. The current documentation does not specify the `responseType` in the HTTP request, which leads to a type mismatch error as the `HttpClient.get` method defaults to returning an `Observable<Object>`.

Changes made:
- Added `{ responseType: 'text' }` as the second argument to the `http.get` method to ensure the response is treated as a plain text string.

This modification ensures that when fetching custom SVG icons, the response is handled as an `Observable<string>`, which aligns with the expected return type for the `provideNgIconLoader` function. The update should prevent type mismatch errors and clarify the correct usage for future developers.

By correcting this example, developers will have a smoother experience when implementing custom SVG icon loaders using the `ng-icons` library.