### PR TITLE
Update Bootstrap Icons to version 1.11.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "UXAspects": "https://gitpkg.now.sh/UXAspects/UXAspects/src/icons/ux?5d63a0e39423bc331994e06e8bb2ba5b5517e799",
     "akar-icons-app": "https://gitpkg.now.sh/artcoholic/akar-icons-app/src/svg?938a77e1fbb1e19d770f1b3c5e3e49daaf2578bc",
     "angular-cli-ghpages": "^1.0.5",
-    "bootstrap-icons": "1.10.5",
+    "bootstrap-icons": "1.11.3",
     "cryptocurrency-icons": "0.18.1",
     "css.gg": "^2.0.0",
     "dripicons": "https://gitpkg.now.sh/amitjakhu/dripicons/SVG?b8b7035c6c0f34035b0a78af4b393a3fd8628c38",


### PR DESCRIPTION
The new version 1.11.x adds more than 100 new icons:
https://blog.getbootstrap.com/2023/09/12/bootstrap-icons-1-11-0/