### PR TITLE
lets-icons: added missing ng-package files to expose the entrypoints

### DIFF
--- a/packages/lets-icons/duotone-line/ng-package.json
+++ b/packages/lets-icons/duotone-line/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "src/index.ts"
+  }
+}

--- a/packages/lets-icons/duotone/ng-package.json
+++ b/packages/lets-icons/duotone/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "src/index.ts"
+  }
+}

--- a/packages/lets-icons/fill/ng-package.json
+++ b/packages/lets-icons/fill/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "src/index.ts"
+  }
+}

--- a/packages/lets-icons/light/ng-package.json
+++ b/packages/lets-icons/light/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "src/index.ts"
+  }
+}

--- a/packages/lets-icons/regular/ng-package.json
+++ b/packages/lets-icons/regular/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "src/index.ts"
+  }
+}


### PR DESCRIPTION
Added the `ng-package.json` files to each subset in Lets Icons, to expose the entrypoints