### PR TITLE
fix: lowering rxjs requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "jsonc-eslint-parser": "^2.1.0",
     "markdown-loader": "^6.0.0",
     "ng-packagr": "18.1.0",
-    "ngx-deploy-npm": "8.0.1",
+    "ngx-deploy-npm": "8.2.0",
     "nx": "19.5.0",
     "postcss": "^8.4.5",
     "postcss-import": "~14.1.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "material-icon-theme": "4.33.0",
     "material-symbols": "0.21.2",
     "remixicon": "4.3.0",
-    "rxjs": "6.6.7",
+    "rxjs": "7.8.0",
     "simple-icons": "13.1.0",
     "tdesign-icons-svg": "^0.2.1",
     "tslib": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "material-icon-theme": "4.33.0",
     "material-symbols": "0.21.2",
     "remixicon": "4.3.0",
-    "rxjs": "7.8.0",
+    "rxjs": "6.6.7",
     "simple-icons": "13.1.0",
     "tdesign-icons-svg": "^0.2.1",
     "tslib": "^2.3.0",

--- a/packages/core/eslint.config.js
+++ b/packages/core/eslint.config.js
@@ -63,6 +63,8 @@ module.exports = [
             '@eslint/js',
             '@ng-icons/feather-icons',
             'jest-preset-angular',
+            '@angular/platform-browser',
+            '@angular/router',
           ],
         },
       ],

--- a/packages/core/eslint.config.js
+++ b/packages/core/eslint.config.js
@@ -50,4 +50,22 @@ module.exports = [
       files: ['**/*.html'],
       rules: {},
     })),
+  ...compat.config({ parser: 'jsonc-eslint-parser' }).map(config => ({
+    ...config,
+    files: ['**/*.json'],
+    rules: {
+      '@nx/dependency-checks': [
+        'error',
+        {
+          ignoredDependencies: [
+            'tslib',
+            '@eslint/eslintrc',
+            '@eslint/js',
+            '@ng-icons/feather-icons',
+            'jest-preset-angular',
+          ],
+        },
+      ],
+    },
+  })),
 ];

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,5 +13,9 @@
   "homepage": "https://ng-icons.github.io/ng-icons/",
   "dependencies": {
     "tslib": "^2.2.0"
+  },
+  "peerDependencies": {
+    "@angular/core": ">=18.0.0",
+    "rxjs": "^6.5.3 || ^7.4.0"
   }
 }

--- a/packages/core/src/lib/utils/async.ts
+++ b/packages/core/src/lib/utils/async.ts
@@ -14,7 +14,7 @@ export function coerceLoaderResult(
   if (isObservable(result)) {
     // toPromise is deprecated, but we can't use lastValueFrom because it's not available in RxJS 6
     // so for now we'll just use toPromise
-    return result.toPromise();
+    return result.toPromise() as Promise<string>;
   }
 
   return result;

--- a/packages/core/src/lib/utils/async.ts
+++ b/packages/core/src/lib/utils/async.ts
@@ -1,4 +1,4 @@
-import { Observable, firstValueFrom, isObservable } from 'rxjs';
+import { Observable, isObservable } from 'rxjs';
 
 /**
  * A loader may return a promise, an observable or a string. This function will coerce the result into a promise.
@@ -12,7 +12,9 @@ export function coerceLoaderResult(
   }
 
   if (isObservable(result)) {
-    return firstValueFrom(result);
+    // toPromise is deprecated, but we can't use lastValueFrom because it's not available in RxJS 6
+    // so for now we'll just use toPromise
+    return result.toPromise();
   }
 
   return result;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -280,8 +280,8 @@ importers:
         specifier: 18.1.0
         version: 18.1.0(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(typescript@5.5.3))(tailwindcss@3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(tslib@2.6.2)(typescript@5.5.3)
       ngx-deploy-npm:
-        specifier: 8.0.1
-        version: 8.0.1(@nx/devkit@19.5.0(nx@19.5.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.5.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))))(tslib@2.6.2)
+        specifier: 8.2.0
+        version: 8.2.0(@nx/devkit@19.5.0(nx@19.5.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.5.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))))(tslib@2.6.2)
       nx:
         specifier: 19.5.0
         version: 19.5.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.5.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))
@@ -6085,11 +6085,11 @@ packages:
       tailwindcss:
         optional: true
 
-  ngx-deploy-npm@8.0.1:
-    resolution: {integrity: sha512-JVgC7OYaa7oqvuVFkm7W+LJ+8+ihmr09NdmIVBcuUAKMzG2rvsnFGc7ymHQJ4RBK2iRVV4oOHtsaruqCBIHprA==}
+  ngx-deploy-npm@8.2.0:
+    resolution: {integrity: sha512-/gN22Q7hI8EediUZLu4DkEaJACw8SRyfNwAvr1eOGx/jlUjAu/nHTGdfRj2GJq7iCOO+yTUPHgCfLneOV2C4tQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      '@nx/devkit': "^16.0.0 ||\_^17.0.0 ||\_^18.0.0"
+      '@nx/devkit': "^16.0.0 ||\_^17.0.0 ||\_^18.0.0 ||\_^19.0.0 ||\_^20.0.0"
       tslib: ^2.3.0
 
   nice-napi@1.0.2:
@@ -15541,7 +15541,7 @@ snapshots:
       rollup: 4.18.0
       tailwindcss: 3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3))
 
-  ngx-deploy-npm@8.0.1(@nx/devkit@19.5.0(nx@19.5.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.5.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))))(tslib@2.6.2):
+  ngx-deploy-npm@8.2.0(@nx/devkit@19.5.0(nx@19.5.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.5.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))))(tslib@2.6.2):
     dependencies:
       '@nx/devkit': 19.5.0(nx@19.5.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.5.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))
       tslib: 2.6.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,31 +10,31 @@ importers:
     dependencies:
       '@angular/animations':
         specifier: 18.1.0
-        version: 18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))
+        version: 18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))
       '@angular/cdk':
         specifier: 18.1.1
-        version: 18.1.1(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7)
+        version: 18.1.1(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0)
       '@angular/common':
         specifier: 18.1.0
-        version: 18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7)
+        version: 18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0)
       '@angular/compiler':
         specifier: 18.1.0
-        version: 18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))
+        version: 18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))
       '@angular/core':
         specifier: 18.1.0
-        version: 18.1.0(rxjs@6.6.7)(zone.js@0.14.3)
+        version: 18.1.0(rxjs@7.8.0)(zone.js@0.14.3)
       '@angular/forms':
         specifier: 18.1.0
-        version: 18.1.0(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(@angular/platform-browser@18.1.0(@angular/animations@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(rxjs@6.6.7)
+        version: 18.1.0(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(@angular/platform-browser@18.1.0(@angular/animations@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(rxjs@7.8.0)
       '@angular/platform-browser':
         specifier: 18.1.0
-        version: 18.1.0(@angular/animations@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))
+        version: 18.1.0(@angular/animations@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))
       '@angular/platform-browser-dynamic':
         specifier: 18.1.0
-        version: 18.1.0(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7))(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(@angular/platform-browser@18.1.0(@angular/animations@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))
+        version: 18.1.0(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0))(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(@angular/platform-browser@18.1.0(@angular/animations@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))
       '@angular/router':
         specifier: 18.1.0
-        version: 18.1.0(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(@angular/platform-browser@18.1.0(@angular/animations@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(rxjs@6.6.7)
+        version: 18.1.0(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(@angular/platform-browser@18.1.0(@angular/animations@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(rxjs@7.8.0)
       '@klarr-agency/circum-icons':
         specifier: https://gitpkg.now.sh/Klarr-Agency/Circum-Icons/svg?6522c0a4aea8fb4c0818228f444f0082d6e6820c
         version: svg?6522c0a4aea8fb4c0818228f444f0082d6e6820c@https://gitpkg.now.sh/Klarr-Agency/Circum-Icons/svg?6522c0a4aea8fb4c0818228f444f0082d6e6820c
@@ -55,10 +55,10 @@ importers:
         version: https://gitpkg.now.sh/radix-ui/icons/packages/radix-icons?237cd76c007a573c2a6f6caabe9ea3de81393f50(react@18.3.1)
       '@rx-angular/cdk':
         specifier: 18.0.0
-        version: 18.0.0(@angular-devkit/core@18.1.1(chokidar@3.6.0))(@angular-devkit/schematics@18.1.1(chokidar@3.6.0))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7)
+        version: 18.0.0(@angular-devkit/core@18.1.1(chokidar@3.6.0))(@angular-devkit/schematics@18.1.1(chokidar@3.6.0))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0)
       '@rx-angular/template':
         specifier: 18.0.0
-        version: 18.0.0(@angular-devkit/core@18.1.1(chokidar@3.6.0))(@angular-devkit/schematics@18.1.1(chokidar@3.6.0))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(@rx-angular/cdk@18.0.0(@angular-devkit/core@18.1.1(chokidar@3.6.0))(@angular-devkit/schematics@18.1.1(chokidar@3.6.0))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7))(rxjs@6.6.7)
+        version: 18.0.0(@angular-devkit/core@18.1.1(chokidar@3.6.0))(@angular-devkit/schematics@18.1.1(chokidar@3.6.0))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(@rx-angular/cdk@18.0.0(@angular-devkit/core@18.1.1(chokidar@3.6.0))(@angular-devkit/schematics@18.1.1(chokidar@3.6.0))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0))(rxjs@7.8.0)
       '@swc/helpers':
         specifier: 0.5.11
         version: 0.5.11
@@ -129,8 +129,8 @@ importers:
         specifier: 4.3.0
         version: 4.3.0
       rxjs:
-        specifier: 6.6.7
-        version: 6.6.7
+        specifier: 7.8.0
+        version: 7.8.0
       simple-icons:
         specifier: 13.1.0
         version: 13.1.0
@@ -149,7 +149,7 @@ importers:
     devDependencies:
       '@angular-devkit/build-angular':
         specifier: 18.1.1
-        version: 18.1.1(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(typescript@5.5.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(chokidar@3.6.0)(jest-environment-jsdom@29.5.0)(jest@29.5.0(@types/node@18.19.33)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(ng-packagr@18.1.0(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(typescript@5.5.3))(tailwindcss@3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(tslib@2.6.2)(typescript@5.5.3))(stylus@0.59.0)(tailwindcss@3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(typescript@5.5.3)
+        version: 18.1.1(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(typescript@5.5.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(chokidar@3.6.0)(jest-environment-jsdom@29.5.0)(jest@29.5.0(@types/node@18.19.33)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(ng-packagr@18.1.0(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(typescript@5.5.3))(tailwindcss@3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(tslib@2.6.2)(typescript@5.5.3))(stylus@0.59.0)(tailwindcss@3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(typescript@5.5.3)
       '@angular-devkit/core':
         specifier: 18.1.1
         version: 18.1.1(chokidar@3.6.0)
@@ -170,7 +170,7 @@ importers:
         version: 18.1.1(chokidar@3.6.0)
       '@angular/compiler-cli':
         specifier: 18.1.0
-        version: 18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(typescript@5.5.3)
+        version: 18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(typescript@5.5.3)
       '@angular/language-service':
         specifier: 18.1.0
         version: 18.1.0
@@ -179,7 +179,7 @@ importers:
         version: 2.1.4
       '@nx/angular':
         specifier: 19.5.0
-        version: 19.5.0(qvx5cvateeopn55murfw4jnmbu)
+        version: 19.5.0(gkn5w4xg77c4o4mfwritvuif7a)
       '@nx/devkit':
         specifier: 19.5.0
         version: 19.5.0(nx@19.5.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.5.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))
@@ -269,7 +269,7 @@ importers:
         version: 29.5.0
       jest-preset-angular:
         specifier: 14.1.0
-        version: 14.1.0(rhclqunrpea3ljkpxvov7tpspq)
+        version: 14.1.0(b3sl2ln4ytgbz27wuxy7ltzsyq)
       jsonc-eslint-parser:
         specifier: ^2.1.0
         version: 2.4.0
@@ -278,7 +278,7 @@ importers:
         version: 6.0.0
       ng-packagr:
         specifier: 18.1.0
-        version: 18.1.0(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(typescript@5.5.3))(tailwindcss@3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(tslib@2.6.2)(typescript@5.5.3)
+        version: 18.1.0(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(typescript@5.5.3))(tailwindcss@3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(tslib@2.6.2)(typescript@5.5.3)
       ngx-deploy-npm:
         specifier: 8.0.1
         version: 8.0.1(@nx/devkit@19.5.0(nx@19.5.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.5.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))))(tslib@2.6.2)
@@ -7150,10 +7150,6 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
-  rxjs@6.6.7:
-    resolution: {integrity: sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==}
-    engines: {npm: '>=2.0.0'}
-
   rxjs@7.8.0:
     resolution: {integrity: sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==}
 
@@ -7779,9 +7775,6 @@ packages:
     resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
     engines: {node: '>=6'}
 
-  tslib@1.14.1:
-    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
-
   tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
 
@@ -8246,14 +8239,14 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@angular-devkit/build-angular@18.1.1(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(typescript@5.5.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(chokidar@3.6.0)(jest-environment-jsdom@29.5.0)(jest@29.5.0(@types/node@18.19.33)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(ng-packagr@18.1.0(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(typescript@5.5.3))(tailwindcss@3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(tslib@2.6.2)(typescript@5.5.3))(stylus@0.59.0)(tailwindcss@3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(typescript@5.5.3)':
+  '@angular-devkit/build-angular@18.1.1(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(typescript@5.5.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(chokidar@3.6.0)(jest-environment-jsdom@29.5.0)(jest@29.5.0(@types/node@18.19.33)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(ng-packagr@18.1.0(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(typescript@5.5.3))(tailwindcss@3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(tslib@2.6.2)(typescript@5.5.3))(stylus@0.59.0)(tailwindcss@3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(typescript@5.5.3)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.1801.1(chokidar@3.6.0)
       '@angular-devkit/build-webpack': 0.1801.1(chokidar@3.6.0)(webpack-dev-server@5.0.4(webpack@5.92.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.21.5)))(webpack@5.92.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.21.5))
       '@angular-devkit/core': 18.1.1(chokidar@3.6.0)
-      '@angular/build': 18.1.1(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(typescript@5.5.3))(@types/node@18.19.33)(chokidar@3.6.0)(less@4.2.0)(postcss@8.4.38)(stylus@0.59.0)(tailwindcss@3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(terser@5.29.2)(typescript@5.5.3)
-      '@angular/compiler-cli': 18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(typescript@5.5.3)
+      '@angular/build': 18.1.1(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(typescript@5.5.3))(@types/node@18.19.33)(chokidar@3.6.0)(less@4.2.0)(postcss@8.4.38)(stylus@0.59.0)(tailwindcss@3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(terser@5.29.2)(typescript@5.5.3)
+      '@angular/compiler-cli': 18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(typescript@5.5.3)
       '@babel/core': 7.24.7
       '@babel/generator': 7.24.7
       '@babel/helper-annotate-as-pure': 7.24.7
@@ -8264,7 +8257,7 @@ snapshots:
       '@babel/preset-env': 7.24.7(@babel/core@7.24.7)
       '@babel/runtime': 7.24.7
       '@discoveryjs/json-ext': 0.5.7
-      '@ngtools/webpack': 18.1.1(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(typescript@5.5.3))(typescript@5.5.3)(webpack@5.92.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.21.5))
+      '@ngtools/webpack': 18.1.1(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(typescript@5.5.3))(typescript@5.5.3)(webpack@5.92.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.21.5))
       '@vitejs/plugin-basic-ssl': 1.1.0(vite@5.3.2(@types/node@18.19.33)(less@4.2.0)(sass@1.77.6)(stylus@0.59.0)(terser@5.29.2))
       ansi-colors: 4.1.3
       autoprefixer: 10.4.19(postcss@8.4.38)
@@ -8317,7 +8310,7 @@ snapshots:
       esbuild: 0.21.5
       jest: 29.5.0(@types/node@18.19.33)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3))
       jest-environment-jsdom: 29.5.0
-      ng-packagr: 18.1.0(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(typescript@5.5.3))(tailwindcss@3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(tslib@2.6.2)(typescript@5.5.3)
+      ng-packagr: 18.1.0(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(typescript@5.5.3))(tailwindcss@3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(tslib@2.6.2)(typescript@5.5.3)
       tailwindcss: 3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3))
     transitivePeerDependencies:
       - '@rspack/core'
@@ -8401,16 +8394,16 @@ snapshots:
       eslint: 8.57.0
       typescript: 5.5.3
 
-  '@angular/animations@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))':
+  '@angular/animations@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))':
     dependencies:
-      '@angular/core': 18.1.0(rxjs@6.6.7)(zone.js@0.14.3)
+      '@angular/core': 18.1.0(rxjs@7.8.0)(zone.js@0.14.3)
       tslib: 2.6.2
 
-  '@angular/build@18.1.1(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(typescript@5.5.3))(@types/node@18.19.33)(chokidar@3.6.0)(less@4.2.0)(postcss@8.4.38)(stylus@0.59.0)(tailwindcss@3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(terser@5.29.2)(typescript@5.5.3)':
+  '@angular/build@18.1.1(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(typescript@5.5.3))(@types/node@18.19.33)(chokidar@3.6.0)(less@4.2.0)(postcss@8.4.38)(stylus@0.59.0)(tailwindcss@3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(terser@5.29.2)(typescript@5.5.3)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.1801.1(chokidar@3.6.0)
-      '@angular/compiler-cli': 18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(typescript@5.5.3)
+      '@angular/compiler-cli': 18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(typescript@5.5.3)
       '@babel/core': 7.24.7
       '@babel/helper-annotate-as-pure': 7.24.7
       '@babel/helper-split-export-declaration': 7.24.7
@@ -8450,11 +8443,11 @@ snapshots:
       - supports-color
       - terser
 
-  '@angular/cdk@18.1.1(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7)':
+  '@angular/cdk@18.1.1(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0)':
     dependencies:
-      '@angular/common': 18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7)
-      '@angular/core': 18.1.0(rxjs@6.6.7)(zone.js@0.14.3)
-      rxjs: 6.6.7
+      '@angular/common': 18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0)
+      '@angular/core': 18.1.0(rxjs@7.8.0)(zone.js@0.14.3)
+      rxjs: 7.8.0
       tslib: 2.6.2
     optionalDependencies:
       parse5: 7.1.2
@@ -8483,15 +8476,15 @@ snapshots:
       - chokidar
       - supports-color
 
-  '@angular/common@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7)':
+  '@angular/common@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0)':
     dependencies:
-      '@angular/core': 18.1.0(rxjs@6.6.7)(zone.js@0.14.3)
-      rxjs: 6.6.7
+      '@angular/core': 18.1.0(rxjs@7.8.0)(zone.js@0.14.3)
+      rxjs: 7.8.0
       tslib: 2.6.2
 
-  '@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(typescript@5.5.3)':
+  '@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(typescript@5.5.3)':
     dependencies:
-      '@angular/compiler': 18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))
+      '@angular/compiler': 18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))
       '@babel/core': 7.24.7
       '@jridgewell/sourcemap-codec': 1.4.15
       chokidar: 3.6.0
@@ -8504,50 +8497,50 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))':
+  '@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))':
     dependencies:
       tslib: 2.6.2
     optionalDependencies:
-      '@angular/core': 18.1.0(rxjs@6.6.7)(zone.js@0.14.3)
+      '@angular/core': 18.1.0(rxjs@7.8.0)(zone.js@0.14.3)
 
-  '@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)':
+  '@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)':
     dependencies:
-      rxjs: 6.6.7
+      rxjs: 7.8.0
       tslib: 2.6.2
       zone.js: 0.14.3
 
-  '@angular/forms@18.1.0(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(@angular/platform-browser@18.1.0(@angular/animations@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(rxjs@6.6.7)':
+  '@angular/forms@18.1.0(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(@angular/platform-browser@18.1.0(@angular/animations@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(rxjs@7.8.0)':
     dependencies:
-      '@angular/common': 18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7)
-      '@angular/core': 18.1.0(rxjs@6.6.7)(zone.js@0.14.3)
-      '@angular/platform-browser': 18.1.0(@angular/animations@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))
-      rxjs: 6.6.7
+      '@angular/common': 18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0)
+      '@angular/core': 18.1.0(rxjs@7.8.0)(zone.js@0.14.3)
+      '@angular/platform-browser': 18.1.0(@angular/animations@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))
+      rxjs: 7.8.0
       tslib: 2.6.2
 
   '@angular/language-service@18.1.0': {}
 
-  '@angular/platform-browser-dynamic@18.1.0(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7))(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(@angular/platform-browser@18.1.0(@angular/animations@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))':
+  '@angular/platform-browser-dynamic@18.1.0(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0))(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(@angular/platform-browser@18.1.0(@angular/animations@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))':
     dependencies:
-      '@angular/common': 18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7)
-      '@angular/compiler': 18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))
-      '@angular/core': 18.1.0(rxjs@6.6.7)(zone.js@0.14.3)
-      '@angular/platform-browser': 18.1.0(@angular/animations@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))
+      '@angular/common': 18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0)
+      '@angular/compiler': 18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))
+      '@angular/core': 18.1.0(rxjs@7.8.0)(zone.js@0.14.3)
+      '@angular/platform-browser': 18.1.0(@angular/animations@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))
       tslib: 2.6.2
 
-  '@angular/platform-browser@18.1.0(@angular/animations@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))':
+  '@angular/platform-browser@18.1.0(@angular/animations@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))':
     dependencies:
-      '@angular/common': 18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7)
-      '@angular/core': 18.1.0(rxjs@6.6.7)(zone.js@0.14.3)
+      '@angular/common': 18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0)
+      '@angular/core': 18.1.0(rxjs@7.8.0)(zone.js@0.14.3)
       tslib: 2.6.2
     optionalDependencies:
-      '@angular/animations': 18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))
+      '@angular/animations': 18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))
 
-  '@angular/router@18.1.0(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(@angular/platform-browser@18.1.0(@angular/animations@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(rxjs@6.6.7)':
+  '@angular/router@18.1.0(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(@angular/platform-browser@18.1.0(@angular/animations@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(rxjs@7.8.0)':
     dependencies:
-      '@angular/common': 18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7)
-      '@angular/core': 18.1.0(rxjs@6.6.7)(zone.js@0.14.3)
-      '@angular/platform-browser': 18.1.0(@angular/animations@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))
-      rxjs: 6.6.7
+      '@angular/common': 18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0)
+      '@angular/core': 18.1.0(rxjs@7.8.0)(zone.js@0.14.3)
+      '@angular/platform-browser': 18.1.0(@angular/animations@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))
+      rxjs: 7.8.0
       tslib: 2.6.2
 
   '@babel/code-frame@7.24.6':
@@ -10925,9 +10918,9 @@ snapshots:
       '@emnapi/runtime': 1.2.0
       '@tybys/wasm-util': 0.9.0
 
-  '@ngtools/webpack@18.1.1(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(typescript@5.5.3))(typescript@5.5.3)(webpack@5.92.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.21.5))':
+  '@ngtools/webpack@18.1.1(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(typescript@5.5.3))(typescript@5.5.3)(webpack@5.92.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.21.5))':
     dependencies:
-      '@angular/compiler-cli': 18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(typescript@5.5.3)
+      '@angular/compiler-cli': 18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(typescript@5.5.3)
       typescript: 5.5.3
       webpack: 5.92.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.21.5)
 
@@ -11007,9 +11000,9 @@ snapshots:
       - bluebird
       - supports-color
 
-  '@nrwl/angular@19.5.0(qvx5cvateeopn55murfw4jnmbu)':
+  '@nrwl/angular@19.5.0(gkn5w4xg77c4o4mfwritvuif7a)':
     dependencies:
-      '@nx/angular': 19.5.0(qvx5cvateeopn55murfw4jnmbu)
+      '@nx/angular': 19.5.0(gkn5w4xg77c4o4mfwritvuif7a)
       tslib: 2.6.3
     transitivePeerDependencies:
       - '@angular-devkit/build-angular'
@@ -11203,13 +11196,13 @@ snapshots:
       - '@swc/core'
       - debug
 
-  '@nx/angular@19.5.0(qvx5cvateeopn55murfw4jnmbu)':
+  '@nx/angular@19.5.0(gkn5w4xg77c4o4mfwritvuif7a)':
     dependencies:
-      '@angular-devkit/build-angular': 18.1.1(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(typescript@5.5.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(chokidar@3.6.0)(jest-environment-jsdom@29.5.0)(jest@29.5.0(@types/node@18.19.33)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(ng-packagr@18.1.0(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(typescript@5.5.3))(tailwindcss@3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(tslib@2.6.2)(typescript@5.5.3))(stylus@0.59.0)(tailwindcss@3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(typescript@5.5.3)
+      '@angular-devkit/build-angular': 18.1.1(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(typescript@5.5.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(chokidar@3.6.0)(jest-environment-jsdom@29.5.0)(jest@29.5.0(@types/node@18.19.33)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(ng-packagr@18.1.0(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(typescript@5.5.3))(tailwindcss@3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(tslib@2.6.2)(typescript@5.5.3))(stylus@0.59.0)(tailwindcss@3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(typescript@5.5.3)
       '@angular-devkit/core': 18.1.1(chokidar@3.6.0)
       '@angular-devkit/schematics': 18.1.1(chokidar@3.6.0)
       '@module-federation/enhanced': 0.2.6(typescript@5.5.3)(webpack@5.91.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.12))
-      '@nrwl/angular': 19.5.0(qvx5cvateeopn55murfw4jnmbu)
+      '@nrwl/angular': 19.5.0(gkn5w4xg77c4o4mfwritvuif7a)
       '@nx/devkit': 19.5.0(nx@19.5.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.5.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))
       '@nx/eslint': 19.5.0(@babel/traverse@7.24.8)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.5.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(@zkochan/js-yaml@0.0.7)(eslint@8.57.0)(nx@19.5.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.5.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))
       '@nx/js': 19.5.0(@babel/traverse@7.24.8)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.5.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(nx@19.5.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.5.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))(typescript@5.5.3)
@@ -11225,7 +11218,7 @@ snapshots:
       magic-string: 0.30.10
       minimatch: 9.0.3
       piscina: 4.5.1
-      rxjs: 6.6.7
+      rxjs: 7.8.0
       semver: 7.6.2
       tslib: 2.6.2
       webpack-merge: 5.10.0
@@ -11560,7 +11553,7 @@ snapshots:
       postcss: 8.4.38
       postcss-import: 14.1.0(postcss@8.4.38)
       postcss-loader: 6.2.1(postcss@8.4.38)(webpack@5.91.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.12))
-      rxjs: 7.8.0
+      rxjs: 7.8.1
       sass: 1.77.2
       sass-loader: 12.6.0(sass@1.77.2)(webpack@5.91.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.12))
       source-map-loader: 5.0.0(webpack@5.91.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.12))
@@ -11714,22 +11707,22 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  '@rx-angular/cdk@18.0.0(@angular-devkit/core@18.1.1(chokidar@3.6.0))(@angular-devkit/schematics@18.1.1(chokidar@3.6.0))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7)':
+  '@rx-angular/cdk@18.0.0(@angular-devkit/core@18.1.1(chokidar@3.6.0))(@angular-devkit/schematics@18.1.1(chokidar@3.6.0))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0)':
     dependencies:
-      '@angular/core': 18.1.0(rxjs@6.6.7)(zone.js@0.14.3)
+      '@angular/core': 18.1.0(rxjs@7.8.0)(zone.js@0.14.3)
       ng-morph: 4.1.2(@angular-devkit/core@18.1.1(chokidar@3.6.0))(@angular-devkit/schematics@18.1.1(chokidar@3.6.0))
-      rxjs: 6.6.7
+      rxjs: 7.8.0
       tslib: 2.6.2
     transitivePeerDependencies:
       - '@angular-devkit/core'
       - '@angular-devkit/schematics'
 
-  '@rx-angular/template@18.0.0(@angular-devkit/core@18.1.1(chokidar@3.6.0))(@angular-devkit/schematics@18.1.1(chokidar@3.6.0))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(@rx-angular/cdk@18.0.0(@angular-devkit/core@18.1.1(chokidar@3.6.0))(@angular-devkit/schematics@18.1.1(chokidar@3.6.0))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7))(rxjs@6.6.7)':
+  '@rx-angular/template@18.0.0(@angular-devkit/core@18.1.1(chokidar@3.6.0))(@angular-devkit/schematics@18.1.1(chokidar@3.6.0))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(@rx-angular/cdk@18.0.0(@angular-devkit/core@18.1.1(chokidar@3.6.0))(@angular-devkit/schematics@18.1.1(chokidar@3.6.0))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0))(rxjs@7.8.0)':
     dependencies:
-      '@angular/core': 18.1.0(rxjs@6.6.7)(zone.js@0.14.3)
-      '@rx-angular/cdk': 18.0.0(@angular-devkit/core@18.1.1(chokidar@3.6.0))(@angular-devkit/schematics@18.1.1(chokidar@3.6.0))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7)
+      '@angular/core': 18.1.0(rxjs@7.8.0)(zone.js@0.14.3)
+      '@rx-angular/cdk': 18.0.0(@angular-devkit/core@18.1.1(chokidar@3.6.0))(@angular-devkit/schematics@18.1.1(chokidar@3.6.0))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0)
       ng-morph: 4.1.2(@angular-devkit/core@18.1.1(chokidar@3.6.0))(@angular-devkit/schematics@18.1.1(chokidar@3.6.0))
-      rxjs: 6.6.7
+      rxjs: 7.8.0
       tslib: 2.6.2
     transitivePeerDependencies:
       - '@angular-devkit/core'
@@ -14742,12 +14735,12 @@ snapshots:
     optionalDependencies:
       jest-resolve: 29.7.0
 
-  jest-preset-angular@14.1.0(rhclqunrpea3ljkpxvov7tpspq):
+  jest-preset-angular@14.1.0(b3sl2ln4ytgbz27wuxy7ltzsyq):
     dependencies:
-      '@angular-devkit/build-angular': 18.1.1(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(typescript@5.5.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(chokidar@3.6.0)(jest-environment-jsdom@29.5.0)(jest@29.5.0(@types/node@18.19.33)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(ng-packagr@18.1.0(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(typescript@5.5.3))(tailwindcss@3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(tslib@2.6.2)(typescript@5.5.3))(stylus@0.59.0)(tailwindcss@3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(typescript@5.5.3)
-      '@angular/compiler-cli': 18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(typescript@5.5.3)
-      '@angular/core': 18.1.0(rxjs@6.6.7)(zone.js@0.14.3)
-      '@angular/platform-browser-dynamic': 18.1.0(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7))(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(@angular/platform-browser@18.1.0(@angular/animations@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))
+      '@angular-devkit/build-angular': 18.1.1(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(typescript@5.5.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(chokidar@3.6.0)(jest-environment-jsdom@29.5.0)(jest@29.5.0(@types/node@18.19.33)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(ng-packagr@18.1.0(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(typescript@5.5.3))(tailwindcss@3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(tslib@2.6.2)(typescript@5.5.3))(stylus@0.59.0)(tailwindcss@3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(typescript@5.5.3)
+      '@angular/compiler-cli': 18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(typescript@5.5.3)
+      '@angular/core': 18.1.0(rxjs@7.8.0)(zone.js@0.14.3)
+      '@angular/platform-browser-dynamic': 18.1.0(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0))(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(@angular/platform-browser@18.1.0(@angular/animations@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))
       bs-logger: 0.2.6
       esbuild-wasm: 0.21.3
       jest: 29.5.0(@types/node@18.19.33)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3))
@@ -15517,9 +15510,9 @@ snapshots:
       ts-morph: 22.0.0
       tslib: 2.6.2
 
-  ng-packagr@18.1.0(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(typescript@5.5.3))(tailwindcss@3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(tslib@2.6.2)(typescript@5.5.3):
+  ng-packagr@18.1.0(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(typescript@5.5.3))(tailwindcss@3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(tslib@2.6.2)(typescript@5.5.3):
     dependencies:
-      '@angular/compiler-cli': 18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(typescript@5.5.3)
+      '@angular/compiler-cli': 18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(typescript@5.5.3)
       '@rollup/plugin-json': 6.1.0(rollup@4.18.0)
       '@rollup/plugin-node-resolve': 15.2.3(rollup@4.18.0)
       '@rollup/wasm-node': 4.18.0
@@ -16673,10 +16666,6 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
-  rxjs@6.6.7:
-    dependencies:
-      tslib: 1.14.1
-
   rxjs@7.8.0:
     dependencies:
       tslib: 2.6.3
@@ -17377,8 +17366,6 @@ snapshots:
       json5: 2.2.3
       minimist: 1.2.8
       strip-bom: 3.0.0
-
-  tslib@1.14.1: {}
 
   tslib@2.6.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,31 +10,31 @@ importers:
     dependencies:
       '@angular/animations':
         specifier: 18.1.0
-        version: 18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))
+        version: 18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))
       '@angular/cdk':
         specifier: 18.1.1
-        version: 18.1.1(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0)
+        version: 18.1.1(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7)
       '@angular/common':
         specifier: 18.1.0
-        version: 18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0)
+        version: 18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7)
       '@angular/compiler':
         specifier: 18.1.0
-        version: 18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))
+        version: 18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))
       '@angular/core':
         specifier: 18.1.0
-        version: 18.1.0(rxjs@7.8.0)(zone.js@0.14.3)
+        version: 18.1.0(rxjs@6.6.7)(zone.js@0.14.3)
       '@angular/forms':
         specifier: 18.1.0
-        version: 18.1.0(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(@angular/platform-browser@18.1.0(@angular/animations@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(rxjs@7.8.0)
+        version: 18.1.0(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(@angular/platform-browser@18.1.0(@angular/animations@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(rxjs@6.6.7)
       '@angular/platform-browser':
         specifier: 18.1.0
-        version: 18.1.0(@angular/animations@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))
+        version: 18.1.0(@angular/animations@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))
       '@angular/platform-browser-dynamic':
         specifier: 18.1.0
-        version: 18.1.0(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0))(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(@angular/platform-browser@18.1.0(@angular/animations@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))
+        version: 18.1.0(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7))(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(@angular/platform-browser@18.1.0(@angular/animations@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))
       '@angular/router':
         specifier: 18.1.0
-        version: 18.1.0(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(@angular/platform-browser@18.1.0(@angular/animations@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(rxjs@7.8.0)
+        version: 18.1.0(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(@angular/platform-browser@18.1.0(@angular/animations@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(rxjs@6.6.7)
       '@klarr-agency/circum-icons':
         specifier: https://gitpkg.now.sh/Klarr-Agency/Circum-Icons/svg?6522c0a4aea8fb4c0818228f444f0082d6e6820c
         version: svg?6522c0a4aea8fb4c0818228f444f0082d6e6820c@https://gitpkg.now.sh/Klarr-Agency/Circum-Icons/svg?6522c0a4aea8fb4c0818228f444f0082d6e6820c
@@ -55,10 +55,10 @@ importers:
         version: https://gitpkg.now.sh/radix-ui/icons/packages/radix-icons?237cd76c007a573c2a6f6caabe9ea3de81393f50(react@18.3.1)
       '@rx-angular/cdk':
         specifier: 18.0.0
-        version: 18.0.0(@angular-devkit/core@18.1.1(chokidar@3.6.0))(@angular-devkit/schematics@18.1.1(chokidar@3.6.0))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0)
+        version: 18.0.0(@angular-devkit/core@18.1.1(chokidar@3.6.0))(@angular-devkit/schematics@18.1.1(chokidar@3.6.0))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7)
       '@rx-angular/template':
         specifier: 18.0.0
-        version: 18.0.0(@angular-devkit/core@18.1.1(chokidar@3.6.0))(@angular-devkit/schematics@18.1.1(chokidar@3.6.0))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(@rx-angular/cdk@18.0.0(@angular-devkit/core@18.1.1(chokidar@3.6.0))(@angular-devkit/schematics@18.1.1(chokidar@3.6.0))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0))(rxjs@7.8.0)
+        version: 18.0.0(@angular-devkit/core@18.1.1(chokidar@3.6.0))(@angular-devkit/schematics@18.1.1(chokidar@3.6.0))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(@rx-angular/cdk@18.0.0(@angular-devkit/core@18.1.1(chokidar@3.6.0))(@angular-devkit/schematics@18.1.1(chokidar@3.6.0))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7))(rxjs@6.6.7)
       '@swc/helpers':
         specifier: 0.5.11
         version: 0.5.11
@@ -129,8 +129,8 @@ importers:
         specifier: 4.3.0
         version: 4.3.0
       rxjs:
-        specifier: 7.8.0
-        version: 7.8.0
+        specifier: 6.6.7
+        version: 6.6.7
       simple-icons:
         specifier: 13.1.0
         version: 13.1.0
@@ -149,7 +149,7 @@ importers:
     devDependencies:
       '@angular-devkit/build-angular':
         specifier: 18.1.1
-        version: 18.1.1(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(typescript@5.5.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(chokidar@3.6.0)(jest-environment-jsdom@29.5.0)(jest@29.5.0(@types/node@18.19.33)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(ng-packagr@18.1.0(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(typescript@5.5.3))(tailwindcss@3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(tslib@2.6.2)(typescript@5.5.3))(stylus@0.59.0)(tailwindcss@3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(typescript@5.5.3)
+        version: 18.1.1(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(typescript@5.5.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(chokidar@3.6.0)(jest-environment-jsdom@29.5.0)(jest@29.5.0(@types/node@18.19.33)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(ng-packagr@18.1.0(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(typescript@5.5.3))(tailwindcss@3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(tslib@2.6.2)(typescript@5.5.3))(stylus@0.59.0)(tailwindcss@3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(typescript@5.5.3)
       '@angular-devkit/core':
         specifier: 18.1.1
         version: 18.1.1(chokidar@3.6.0)
@@ -170,7 +170,7 @@ importers:
         version: 18.1.1(chokidar@3.6.0)
       '@angular/compiler-cli':
         specifier: 18.1.0
-        version: 18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(typescript@5.5.3)
+        version: 18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(typescript@5.5.3)
       '@angular/language-service':
         specifier: 18.1.0
         version: 18.1.0
@@ -179,7 +179,7 @@ importers:
         version: 2.1.4
       '@nx/angular':
         specifier: 19.5.0
-        version: 19.5.0(gkn5w4xg77c4o4mfwritvuif7a)
+        version: 19.5.0(qvx5cvateeopn55murfw4jnmbu)
       '@nx/devkit':
         specifier: 19.5.0
         version: 19.5.0(nx@19.5.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.5.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))
@@ -269,7 +269,7 @@ importers:
         version: 29.5.0
       jest-preset-angular:
         specifier: 14.1.0
-        version: 14.1.0(b3sl2ln4ytgbz27wuxy7ltzsyq)
+        version: 14.1.0(rhclqunrpea3ljkpxvov7tpspq)
       jsonc-eslint-parser:
         specifier: ^2.1.0
         version: 2.4.0
@@ -278,7 +278,7 @@ importers:
         version: 6.0.0
       ng-packagr:
         specifier: 18.1.0
-        version: 18.1.0(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(typescript@5.5.3))(tailwindcss@3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(tslib@2.6.2)(typescript@5.5.3)
+        version: 18.1.0(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(typescript@5.5.3))(tailwindcss@3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(tslib@2.6.2)(typescript@5.5.3)
       ngx-deploy-npm:
         specifier: 8.0.1
         version: 8.0.1(@nx/devkit@19.5.0(nx@19.5.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.5.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))))(tslib@2.6.2)
@@ -7150,6 +7150,10 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
+  rxjs@6.6.7:
+    resolution: {integrity: sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==}
+    engines: {npm: '>=2.0.0'}
+
   rxjs@7.8.0:
     resolution: {integrity: sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==}
 
@@ -7775,6 +7779,9 @@ packages:
     resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
     engines: {node: '>=6'}
 
+  tslib@1.14.1:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
+
   tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
 
@@ -8239,14 +8246,14 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@angular-devkit/build-angular@18.1.1(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(typescript@5.5.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(chokidar@3.6.0)(jest-environment-jsdom@29.5.0)(jest@29.5.0(@types/node@18.19.33)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(ng-packagr@18.1.0(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(typescript@5.5.3))(tailwindcss@3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(tslib@2.6.2)(typescript@5.5.3))(stylus@0.59.0)(tailwindcss@3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(typescript@5.5.3)':
+  '@angular-devkit/build-angular@18.1.1(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(typescript@5.5.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(chokidar@3.6.0)(jest-environment-jsdom@29.5.0)(jest@29.5.0(@types/node@18.19.33)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(ng-packagr@18.1.0(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(typescript@5.5.3))(tailwindcss@3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(tslib@2.6.2)(typescript@5.5.3))(stylus@0.59.0)(tailwindcss@3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(typescript@5.5.3)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.1801.1(chokidar@3.6.0)
       '@angular-devkit/build-webpack': 0.1801.1(chokidar@3.6.0)(webpack-dev-server@5.0.4(webpack@5.92.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.21.5)))(webpack@5.92.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.21.5))
       '@angular-devkit/core': 18.1.1(chokidar@3.6.0)
-      '@angular/build': 18.1.1(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(typescript@5.5.3))(@types/node@18.19.33)(chokidar@3.6.0)(less@4.2.0)(postcss@8.4.38)(stylus@0.59.0)(tailwindcss@3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(terser@5.29.2)(typescript@5.5.3)
-      '@angular/compiler-cli': 18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(typescript@5.5.3)
+      '@angular/build': 18.1.1(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(typescript@5.5.3))(@types/node@18.19.33)(chokidar@3.6.0)(less@4.2.0)(postcss@8.4.38)(stylus@0.59.0)(tailwindcss@3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(terser@5.29.2)(typescript@5.5.3)
+      '@angular/compiler-cli': 18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(typescript@5.5.3)
       '@babel/core': 7.24.7
       '@babel/generator': 7.24.7
       '@babel/helper-annotate-as-pure': 7.24.7
@@ -8257,7 +8264,7 @@ snapshots:
       '@babel/preset-env': 7.24.7(@babel/core@7.24.7)
       '@babel/runtime': 7.24.7
       '@discoveryjs/json-ext': 0.5.7
-      '@ngtools/webpack': 18.1.1(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(typescript@5.5.3))(typescript@5.5.3)(webpack@5.92.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.21.5))
+      '@ngtools/webpack': 18.1.1(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(typescript@5.5.3))(typescript@5.5.3)(webpack@5.92.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.21.5))
       '@vitejs/plugin-basic-ssl': 1.1.0(vite@5.3.2(@types/node@18.19.33)(less@4.2.0)(sass@1.77.6)(stylus@0.59.0)(terser@5.29.2))
       ansi-colors: 4.1.3
       autoprefixer: 10.4.19(postcss@8.4.38)
@@ -8310,7 +8317,7 @@ snapshots:
       esbuild: 0.21.5
       jest: 29.5.0(@types/node@18.19.33)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3))
       jest-environment-jsdom: 29.5.0
-      ng-packagr: 18.1.0(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(typescript@5.5.3))(tailwindcss@3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(tslib@2.6.2)(typescript@5.5.3)
+      ng-packagr: 18.1.0(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(typescript@5.5.3))(tailwindcss@3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(tslib@2.6.2)(typescript@5.5.3)
       tailwindcss: 3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3))
     transitivePeerDependencies:
       - '@rspack/core'
@@ -8394,16 +8401,16 @@ snapshots:
       eslint: 8.57.0
       typescript: 5.5.3
 
-  '@angular/animations@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))':
+  '@angular/animations@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))':
     dependencies:
-      '@angular/core': 18.1.0(rxjs@7.8.0)(zone.js@0.14.3)
+      '@angular/core': 18.1.0(rxjs@6.6.7)(zone.js@0.14.3)
       tslib: 2.6.2
 
-  '@angular/build@18.1.1(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(typescript@5.5.3))(@types/node@18.19.33)(chokidar@3.6.0)(less@4.2.0)(postcss@8.4.38)(stylus@0.59.0)(tailwindcss@3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(terser@5.29.2)(typescript@5.5.3)':
+  '@angular/build@18.1.1(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(typescript@5.5.3))(@types/node@18.19.33)(chokidar@3.6.0)(less@4.2.0)(postcss@8.4.38)(stylus@0.59.0)(tailwindcss@3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(terser@5.29.2)(typescript@5.5.3)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.1801.1(chokidar@3.6.0)
-      '@angular/compiler-cli': 18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(typescript@5.5.3)
+      '@angular/compiler-cli': 18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(typescript@5.5.3)
       '@babel/core': 7.24.7
       '@babel/helper-annotate-as-pure': 7.24.7
       '@babel/helper-split-export-declaration': 7.24.7
@@ -8443,11 +8450,11 @@ snapshots:
       - supports-color
       - terser
 
-  '@angular/cdk@18.1.1(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0)':
+  '@angular/cdk@18.1.1(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7)':
     dependencies:
-      '@angular/common': 18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0)
-      '@angular/core': 18.1.0(rxjs@7.8.0)(zone.js@0.14.3)
-      rxjs: 7.8.0
+      '@angular/common': 18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7)
+      '@angular/core': 18.1.0(rxjs@6.6.7)(zone.js@0.14.3)
+      rxjs: 6.6.7
       tslib: 2.6.2
     optionalDependencies:
       parse5: 7.1.2
@@ -8476,15 +8483,15 @@ snapshots:
       - chokidar
       - supports-color
 
-  '@angular/common@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0)':
+  '@angular/common@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7)':
     dependencies:
-      '@angular/core': 18.1.0(rxjs@7.8.0)(zone.js@0.14.3)
-      rxjs: 7.8.0
+      '@angular/core': 18.1.0(rxjs@6.6.7)(zone.js@0.14.3)
+      rxjs: 6.6.7
       tslib: 2.6.2
 
-  '@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(typescript@5.5.3)':
+  '@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(typescript@5.5.3)':
     dependencies:
-      '@angular/compiler': 18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))
+      '@angular/compiler': 18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))
       '@babel/core': 7.24.7
       '@jridgewell/sourcemap-codec': 1.4.15
       chokidar: 3.6.0
@@ -8497,50 +8504,50 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))':
+  '@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))':
     dependencies:
       tslib: 2.6.2
     optionalDependencies:
-      '@angular/core': 18.1.0(rxjs@7.8.0)(zone.js@0.14.3)
+      '@angular/core': 18.1.0(rxjs@6.6.7)(zone.js@0.14.3)
 
-  '@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)':
+  '@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)':
     dependencies:
-      rxjs: 7.8.0
+      rxjs: 6.6.7
       tslib: 2.6.2
       zone.js: 0.14.3
 
-  '@angular/forms@18.1.0(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(@angular/platform-browser@18.1.0(@angular/animations@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(rxjs@7.8.0)':
+  '@angular/forms@18.1.0(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(@angular/platform-browser@18.1.0(@angular/animations@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(rxjs@6.6.7)':
     dependencies:
-      '@angular/common': 18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0)
-      '@angular/core': 18.1.0(rxjs@7.8.0)(zone.js@0.14.3)
-      '@angular/platform-browser': 18.1.0(@angular/animations@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))
-      rxjs: 7.8.0
+      '@angular/common': 18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7)
+      '@angular/core': 18.1.0(rxjs@6.6.7)(zone.js@0.14.3)
+      '@angular/platform-browser': 18.1.0(@angular/animations@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))
+      rxjs: 6.6.7
       tslib: 2.6.2
 
   '@angular/language-service@18.1.0': {}
 
-  '@angular/platform-browser-dynamic@18.1.0(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0))(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(@angular/platform-browser@18.1.0(@angular/animations@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))':
+  '@angular/platform-browser-dynamic@18.1.0(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7))(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(@angular/platform-browser@18.1.0(@angular/animations@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))':
     dependencies:
-      '@angular/common': 18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0)
-      '@angular/compiler': 18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))
-      '@angular/core': 18.1.0(rxjs@7.8.0)(zone.js@0.14.3)
-      '@angular/platform-browser': 18.1.0(@angular/animations@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))
+      '@angular/common': 18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7)
+      '@angular/compiler': 18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))
+      '@angular/core': 18.1.0(rxjs@6.6.7)(zone.js@0.14.3)
+      '@angular/platform-browser': 18.1.0(@angular/animations@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))
       tslib: 2.6.2
 
-  '@angular/platform-browser@18.1.0(@angular/animations@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))':
+  '@angular/platform-browser@18.1.0(@angular/animations@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))':
     dependencies:
-      '@angular/common': 18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0)
-      '@angular/core': 18.1.0(rxjs@7.8.0)(zone.js@0.14.3)
+      '@angular/common': 18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7)
+      '@angular/core': 18.1.0(rxjs@6.6.7)(zone.js@0.14.3)
       tslib: 2.6.2
     optionalDependencies:
-      '@angular/animations': 18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))
+      '@angular/animations': 18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))
 
-  '@angular/router@18.1.0(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(@angular/platform-browser@18.1.0(@angular/animations@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(rxjs@7.8.0)':
+  '@angular/router@18.1.0(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(@angular/platform-browser@18.1.0(@angular/animations@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(rxjs@6.6.7)':
     dependencies:
-      '@angular/common': 18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0)
-      '@angular/core': 18.1.0(rxjs@7.8.0)(zone.js@0.14.3)
-      '@angular/platform-browser': 18.1.0(@angular/animations@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))
-      rxjs: 7.8.0
+      '@angular/common': 18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7)
+      '@angular/core': 18.1.0(rxjs@6.6.7)(zone.js@0.14.3)
+      '@angular/platform-browser': 18.1.0(@angular/animations@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))
+      rxjs: 6.6.7
       tslib: 2.6.2
 
   '@babel/code-frame@7.24.6':
@@ -10165,15 +10172,15 @@ snapshots:
   '@emnapi/core@1.2.0':
     dependencies:
       '@emnapi/wasi-threads': 1.0.1
-      tslib: 2.6.2
+      tslib: 2.6.3
 
   '@emnapi/runtime@1.2.0':
     dependencies:
-      tslib: 2.6.2
+      tslib: 2.6.3
 
   '@emnapi/wasi-threads@1.0.1':
     dependencies:
-      tslib: 2.6.2
+      tslib: 2.6.3
 
   '@esbuild/aix-ppc64@0.19.12':
     optional: true
@@ -10918,9 +10925,9 @@ snapshots:
       '@emnapi/runtime': 1.2.0
       '@tybys/wasm-util': 0.9.0
 
-  '@ngtools/webpack@18.1.1(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(typescript@5.5.3))(typescript@5.5.3)(webpack@5.92.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.21.5))':
+  '@ngtools/webpack@18.1.1(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(typescript@5.5.3))(typescript@5.5.3)(webpack@5.92.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.21.5))':
     dependencies:
-      '@angular/compiler-cli': 18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(typescript@5.5.3)
+      '@angular/compiler-cli': 18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(typescript@5.5.3)
       typescript: 5.5.3
       webpack: 5.92.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.21.5)
 
@@ -11000,10 +11007,10 @@ snapshots:
       - bluebird
       - supports-color
 
-  '@nrwl/angular@19.5.0(gkn5w4xg77c4o4mfwritvuif7a)':
+  '@nrwl/angular@19.5.0(qvx5cvateeopn55murfw4jnmbu)':
     dependencies:
-      '@nx/angular': 19.5.0(gkn5w4xg77c4o4mfwritvuif7a)
-      tslib: 2.6.2
+      '@nx/angular': 19.5.0(qvx5cvateeopn55murfw4jnmbu)
+      tslib: 2.6.3
     transitivePeerDependencies:
       - '@angular-devkit/build-angular'
       - '@angular-devkit/core'
@@ -11136,7 +11143,7 @@ snapshots:
   '@nrwl/tao@19.5.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.5.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))':
     dependencies:
       nx: 19.5.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.5.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))
-      tslib: 2.6.2
+      tslib: 2.6.3
     transitivePeerDependencies:
       - '@swc-node/register'
       - '@swc/core'
@@ -11196,13 +11203,13 @@ snapshots:
       - '@swc/core'
       - debug
 
-  '@nx/angular@19.5.0(gkn5w4xg77c4o4mfwritvuif7a)':
+  '@nx/angular@19.5.0(qvx5cvateeopn55murfw4jnmbu)':
     dependencies:
-      '@angular-devkit/build-angular': 18.1.1(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(typescript@5.5.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(chokidar@3.6.0)(jest-environment-jsdom@29.5.0)(jest@29.5.0(@types/node@18.19.33)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(ng-packagr@18.1.0(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(typescript@5.5.3))(tailwindcss@3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(tslib@2.6.2)(typescript@5.5.3))(stylus@0.59.0)(tailwindcss@3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(typescript@5.5.3)
+      '@angular-devkit/build-angular': 18.1.1(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(typescript@5.5.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(chokidar@3.6.0)(jest-environment-jsdom@29.5.0)(jest@29.5.0(@types/node@18.19.33)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(ng-packagr@18.1.0(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(typescript@5.5.3))(tailwindcss@3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(tslib@2.6.2)(typescript@5.5.3))(stylus@0.59.0)(tailwindcss@3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(typescript@5.5.3)
       '@angular-devkit/core': 18.1.1(chokidar@3.6.0)
       '@angular-devkit/schematics': 18.1.1(chokidar@3.6.0)
       '@module-federation/enhanced': 0.2.6(typescript@5.5.3)(webpack@5.91.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.12))
-      '@nrwl/angular': 19.5.0(gkn5w4xg77c4o4mfwritvuif7a)
+      '@nrwl/angular': 19.5.0(qvx5cvateeopn55murfw4jnmbu)
       '@nx/devkit': 19.5.0(nx@19.5.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.5.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))
       '@nx/eslint': 19.5.0(@babel/traverse@7.24.8)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.5.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(@zkochan/js-yaml@0.0.7)(eslint@8.57.0)(nx@19.5.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.5.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))
       '@nx/js': 19.5.0(@babel/traverse@7.24.8)(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.5.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(nx@19.5.0(@swc-node/register@1.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.5.3))(@swc/core@1.5.7(@swc/helpers@0.5.11)))(typescript@5.5.3)
@@ -11218,7 +11225,7 @@ snapshots:
       magic-string: 0.30.10
       minimatch: 9.0.3
       piscina: 4.5.1
-      rxjs: 7.8.0
+      rxjs: 6.6.7
       semver: 7.6.2
       tslib: 2.6.2
       webpack-merge: 5.10.0
@@ -11514,7 +11521,7 @@ snapshots:
       chalk: 4.1.2
       detect-port: 1.6.1
       http-server: 14.1.1
-      tslib: 2.6.2
+      tslib: 2.6.3
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -11563,7 +11570,7 @@ snapshots:
       terser-webpack-plugin: 5.3.10(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.12)(webpack@5.91.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.12))
       ts-loader: 9.5.1(typescript@5.5.3)(webpack@5.91.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.12))
       tsconfig-paths-webpack-plugin: 4.0.0
-      tslib: 2.6.2
+      tslib: 2.6.3
       webpack: 5.91.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.12)
       webpack-dev-server: 4.15.2(webpack@5.91.0(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.19.12))
       webpack-node-externals: 3.0.0
@@ -11707,22 +11714,22 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  '@rx-angular/cdk@18.0.0(@angular-devkit/core@18.1.1(chokidar@3.6.0))(@angular-devkit/schematics@18.1.1(chokidar@3.6.0))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0)':
+  '@rx-angular/cdk@18.0.0(@angular-devkit/core@18.1.1(chokidar@3.6.0))(@angular-devkit/schematics@18.1.1(chokidar@3.6.0))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7)':
     dependencies:
-      '@angular/core': 18.1.0(rxjs@7.8.0)(zone.js@0.14.3)
+      '@angular/core': 18.1.0(rxjs@6.6.7)(zone.js@0.14.3)
       ng-morph: 4.1.2(@angular-devkit/core@18.1.1(chokidar@3.6.0))(@angular-devkit/schematics@18.1.1(chokidar@3.6.0))
-      rxjs: 7.8.0
+      rxjs: 6.6.7
       tslib: 2.6.2
     transitivePeerDependencies:
       - '@angular-devkit/core'
       - '@angular-devkit/schematics'
 
-  '@rx-angular/template@18.0.0(@angular-devkit/core@18.1.1(chokidar@3.6.0))(@angular-devkit/schematics@18.1.1(chokidar@3.6.0))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(@rx-angular/cdk@18.0.0(@angular-devkit/core@18.1.1(chokidar@3.6.0))(@angular-devkit/schematics@18.1.1(chokidar@3.6.0))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0))(rxjs@7.8.0)':
+  '@rx-angular/template@18.0.0(@angular-devkit/core@18.1.1(chokidar@3.6.0))(@angular-devkit/schematics@18.1.1(chokidar@3.6.0))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(@rx-angular/cdk@18.0.0(@angular-devkit/core@18.1.1(chokidar@3.6.0))(@angular-devkit/schematics@18.1.1(chokidar@3.6.0))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7))(rxjs@6.6.7)':
     dependencies:
-      '@angular/core': 18.1.0(rxjs@7.8.0)(zone.js@0.14.3)
-      '@rx-angular/cdk': 18.0.0(@angular-devkit/core@18.1.1(chokidar@3.6.0))(@angular-devkit/schematics@18.1.1(chokidar@3.6.0))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0)
+      '@angular/core': 18.1.0(rxjs@6.6.7)(zone.js@0.14.3)
+      '@rx-angular/cdk': 18.0.0(@angular-devkit/core@18.1.1(chokidar@3.6.0))(@angular-devkit/schematics@18.1.1(chokidar@3.6.0))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7)
       ng-morph: 4.1.2(@angular-devkit/core@18.1.1(chokidar@3.6.0))(@angular-devkit/schematics@18.1.1(chokidar@3.6.0))
-      rxjs: 7.8.0
+      rxjs: 6.6.7
       tslib: 2.6.2
     transitivePeerDependencies:
       - '@angular-devkit/core'
@@ -11806,7 +11813,7 @@ snapshots:
   '@swc-node/sourcemap-support@0.5.0':
     dependencies:
       source-map-support: 0.5.21
-      tslib: 2.6.2
+      tslib: 2.6.3
 
   '@swc/cli@0.3.12(@swc/core@1.5.7(@swc/helpers@0.5.11))(chokidar@3.6.0)':
     dependencies:
@@ -11923,7 +11930,7 @@ snapshots:
 
   '@tybys/wasm-util@0.9.0':
     dependencies:
-      tslib: 2.6.2
+      tslib: 2.6.3
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -12294,7 +12301,7 @@ snapshots:
   '@yarnpkg/parsers@3.0.0-rc.46':
     dependencies:
       js-yaml: 3.14.1
-      tslib: 2.6.2
+      tslib: 2.6.3
 
   '@zkochan/js-yaml@0.0.7':
     dependencies:
@@ -12805,7 +12812,7 @@ snapshots:
   camel-case@4.1.2:
     dependencies:
       pascal-case: 3.1.2
-      tslib: 2.6.2
+      tslib: 2.6.3
 
   camelcase-css@2.0.1: {}
 
@@ -13417,7 +13424,7 @@ snapshots:
   dot-case@3.0.4:
     dependencies:
       no-case: 3.0.4
-      tslib: 2.6.2
+      tslib: 2.6.3
 
   dotenv-expand@11.0.6:
     dependencies:
@@ -14391,7 +14398,7 @@ snapshots:
 
   injection-js@2.4.0:
     dependencies:
-      tslib: 2.6.2
+      tslib: 2.6.3
 
   ionicons@7.4.0:
     dependencies:
@@ -14735,12 +14742,12 @@ snapshots:
     optionalDependencies:
       jest-resolve: 29.7.0
 
-  jest-preset-angular@14.1.0(b3sl2ln4ytgbz27wuxy7ltzsyq):
+  jest-preset-angular@14.1.0(rhclqunrpea3ljkpxvov7tpspq):
     dependencies:
-      '@angular-devkit/build-angular': 18.1.1(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(typescript@5.5.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(chokidar@3.6.0)(jest-environment-jsdom@29.5.0)(jest@29.5.0(@types/node@18.19.33)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(ng-packagr@18.1.0(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(typescript@5.5.3))(tailwindcss@3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(tslib@2.6.2)(typescript@5.5.3))(stylus@0.59.0)(tailwindcss@3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(typescript@5.5.3)
-      '@angular/compiler-cli': 18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(typescript@5.5.3)
-      '@angular/core': 18.1.0(rxjs@7.8.0)(zone.js@0.14.3)
-      '@angular/platform-browser-dynamic': 18.1.0(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0))(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(@angular/platform-browser@18.1.0(@angular/animations@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3))(rxjs@7.8.0))(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))
+      '@angular-devkit/build-angular': 18.1.1(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(typescript@5.5.3))(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(chokidar@3.6.0)(jest-environment-jsdom@29.5.0)(jest@29.5.0(@types/node@18.19.33)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(ng-packagr@18.1.0(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(typescript@5.5.3))(tailwindcss@3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(tslib@2.6.2)(typescript@5.5.3))(stylus@0.59.0)(tailwindcss@3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(typescript@5.5.3)
+      '@angular/compiler-cli': 18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(typescript@5.5.3)
+      '@angular/core': 18.1.0(rxjs@6.6.7)(zone.js@0.14.3)
+      '@angular/platform-browser-dynamic': 18.1.0(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7))(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(@angular/platform-browser@18.1.0(@angular/animations@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(@angular/common@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3))(rxjs@6.6.7))(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))
       bs-logger: 0.2.6
       esbuild-wasm: 0.21.3
       jest: 29.5.0(@types/node@18.19.33)(babel-plugin-macros@3.1.0)(node-notifier@8.0.2)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3))
@@ -15089,7 +15096,7 @@ snapshots:
     dependencies:
       copy-anything: 2.0.6
       parse-node-version: 1.0.1
-      tslib: 2.6.2
+      tslib: 2.6.3
     optionalDependencies:
       errno: 0.1.8
       graceful-fs: 4.2.11
@@ -15241,7 +15248,7 @@ snapshots:
 
   lower-case@2.0.2:
     dependencies:
-      tslib: 2.6.2
+      tslib: 2.6.3
 
   lowercase-keys@2.0.0: {}
 
@@ -15510,9 +15517,9 @@ snapshots:
       ts-morph: 22.0.0
       tslib: 2.6.2
 
-  ng-packagr@18.1.0(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(typescript@5.5.3))(tailwindcss@3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(tslib@2.6.2)(typescript@5.5.3):
+  ng-packagr@18.1.0(@angular/compiler-cli@18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(typescript@5.5.3))(tailwindcss@3.0.24(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@18.19.33)(typescript@5.5.3)))(tslib@2.6.2)(typescript@5.5.3):
     dependencies:
-      '@angular/compiler-cli': 18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@7.8.0)(zone.js@0.14.3)))(typescript@5.5.3)
+      '@angular/compiler-cli': 18.1.0(@angular/compiler@18.1.0(@angular/core@18.1.0(rxjs@6.6.7)(zone.js@0.14.3)))(typescript@5.5.3)
       '@rollup/plugin-json': 6.1.0(rollup@4.18.0)
       '@rollup/plugin-node-resolve': 15.2.3(rollup@4.18.0)
       '@rollup/wasm-node': 4.18.0
@@ -15555,7 +15562,7 @@ snapshots:
   no-case@3.0.4:
     dependencies:
       lower-case: 2.0.2
-      tslib: 2.6.2
+      tslib: 2.6.3
 
   node-abort-controller@3.1.1: {}
 
@@ -15895,7 +15902,7 @@ snapshots:
   param-case@3.0.4:
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.6.2
+      tslib: 2.6.3
 
   parent-module@1.0.1:
     dependencies:
@@ -15935,7 +15942,7 @@ snapshots:
   pascal-case@3.1.2:
     dependencies:
       no-case: 3.0.4
-      tslib: 2.6.2
+      tslib: 2.6.3
 
   path-browserify@1.0.1: {}
 
@@ -16666,9 +16673,13 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
+  rxjs@6.6.7:
+    dependencies:
+      tslib: 1.14.1
+
   rxjs@7.8.0:
     dependencies:
-      tslib: 2.6.2
+      tslib: 2.6.3
 
   rxjs@7.8.1:
     dependencies:
@@ -17366,6 +17377,8 @@ snapshots:
       json5: 2.2.3
       minimist: 1.2.8
       strip-bom: 3.0.0
+
+  tslib@1.14.1: {}
 
   tslib@2.6.2: {}
 


### PR DESCRIPTION
- Adding peer dependency requirement to package.json
- Removing use of RxJS v7 feature to support older version

Closes #120