### PR TITLE
fix: retain additional child elements

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "nx run-many --target=test --all --parallel=8 --runInBand",
     "compile": "nx generate @ng-icons/workspace-plugin:svg-to-ts && nx run-many --target=build --all --parallel=8 && nx generate @ng-icons/workspace-plugin:update-readmes",
     "generate:iconsets": "nx generate @ng-icons/workspace-plugin:svg-to-ts",
-    "deploy": "nx run-many --all --target=deploy --parallel=8 --packageVersion=29.0.0"
+    "deploy": "nx run-many --all --target=deploy --parallel=8 --packageVersion=29.1.0"
   },
   "private": true,
   "dependencies": {

--- a/packages/core/src/lib/components/icon/__snapshots__/icon.component.spec.ts.snap
+++ b/packages/core/src/lib/components/icon/__snapshots__/icon.component.spec.ts.snap
@@ -101,4 +101,6 @@ exports[`Icon should insert the expected template 1`] = `
 </div>
 `;
 
+exports[`Icon should not remove additional child elements 1`] = `"<div id=\\"root0\\" ng-version=\\"18.1.0\\" style=\\"--ng-icon__size: 1em;\\"><span>1</span><svg xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 24 24\\" fill=\\"none\\" stroke=\\"currentColor\\" stroke-linecap=\\"round\\" stroke-linejoin=\\"round\\" style=\\"stroke-width:var(--ng-icon__stroke-width, 2)\\"><path d=\\"M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z\\"></path><line x1=\\"12\\" y1=\\"9\\" x2=\\"12\\" y2=\\"13\\"></line><line x1=\\"12\\" y1=\\"17\\" x2=\\"12.01\\" y2=\\"17\\"></line></svg></div>"`;
+
 exports[`Standalone icon component should display the icon 1`] = `"<svg xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 24 24\\" fill=\\"none\\" stroke=\\"currentColor\\" stroke-linecap=\\"round\\" stroke-linejoin=\\"round\\" style=\\"stroke-width:var(--ng-icon__stroke-width, 2)\\"><circle cx=\\"12\\" cy=\\"12\\" r=\\"10\\"></circle><line x1=\\"12\\" y1=\\"8\\" x2=\\"12\\" y2=\\"12\\"></line><line x1=\\"12\\" y1=\\"16\\" x2=\\"12.01\\" y2=\\"16\\"></line></svg>"`;

--- a/packages/core/src/lib/components/icon/__snapshots__/icon.component.spec.ts.snap
+++ b/packages/core/src/lib/components/icon/__snapshots__/icon.component.spec.ts.snap
@@ -35,7 +35,7 @@ exports[`Icon should allow the icon to change 1`] = `
 
 exports[`Icon should allow the icon to change by passing in a svg 1`] = `
 <div
-  id="root2"
+  id="root3"
   style="--ng-icon__size: 1em;"
 >
   <svg
@@ -101,6 +101,6 @@ exports[`Icon should insert the expected template 1`] = `
 </div>
 `;
 
-exports[`Icon should not remove additional child elements 1`] = `"<div id=\\"root0\\" ng-version=\\"18.1.0\\" style=\\"--ng-icon__size: 1em;\\"><span>1</span><svg xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 24 24\\" fill=\\"none\\" stroke=\\"currentColor\\" stroke-linecap=\\"round\\" stroke-linejoin=\\"round\\" style=\\"stroke-width:var(--ng-icon__stroke-width, 2)\\"><path d=\\"M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z\\"></path><line x1=\\"12\\" y1=\\"9\\" x2=\\"12\\" y2=\\"13\\"></line><line x1=\\"12\\" y1=\\"17\\" x2=\\"12.01\\" y2=\\"17\\"></line></svg></div>"`;
+exports[`Icon should not remove additional child elements 1`] = `"<div id=\\"root2\\" ng-version=\\"18.1.0\\" style=\\"--ng-icon__size: 1em;\\"><span>1</span><svg xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 24 24\\" fill=\\"none\\" stroke=\\"currentColor\\" stroke-linecap=\\"round\\" stroke-linejoin=\\"round\\" style=\\"stroke-width:var(--ng-icon__stroke-width, 2)\\"><path d=\\"M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z\\"></path><line x1=\\"12\\" y1=\\"9\\" x2=\\"12\\" y2=\\"13\\"></line><line x1=\\"12\\" y1=\\"17\\" x2=\\"12.01\\" y2=\\"17\\"></line></svg></div>"`;
 
 exports[`Standalone icon component should display the icon 1`] = `"<svg xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 24 24\\" fill=\\"none\\" stroke=\\"currentColor\\" stroke-linecap=\\"round\\" stroke-linejoin=\\"round\\" style=\\"stroke-width:var(--ng-icon__stroke-width, 2)\\"><circle cx=\\"12\\" cy=\\"12\\" r=\\"10\\"></circle><line x1=\\"12\\" y1=\\"8\\" x2=\\"12\\" y2=\\"12\\"></line><line x1=\\"12\\" y1=\\"16\\" x2=\\"12.01\\" y2=\\"16\\"></line></svg>"`;

--- a/packages/core/src/lib/components/icon/icon.component.spec.ts
+++ b/packages/core/src/lib/components/icon/icon.component.spec.ts
@@ -50,6 +50,19 @@ describe('Icon', () => {
     expect(nativeElement).toMatchSnapshot();
   });
 
+  // regression test for https://github.com/ng-icons/ng-icons/issues/127
+  it('should not remove additional child elements', () => {
+    const badge = document.createElement('span');
+    badge.textContent = '1';
+
+    fixture.nativeElement.appendChild(badge);
+
+    fixture.componentRef.setInput('name', 'featherAlertTriangle');
+    fixture.detectChanges();
+
+    expect(nativeElement.outerHTML).toMatchSnapshot();
+  });
+
   it('should allow the icon to change by passing in a svg', () => {
     fixture.componentRef.setInput('svg', featherAlertTriangle);
     fixture.detectChanges();

--- a/packages/core/src/lib/components/icon/icon.component.ts
+++ b/packages/core/src/lib/components/icon/icon.component.ts
@@ -83,6 +83,9 @@ export class NgIcon {
   /** Define the color of the icon */
   readonly color = input(this.config.color);
 
+  /** Store the inserted SVG */
+  private svgElement?: SVGElement;
+
   constructor() {
     // update the icon anytime the name or svg changes
     effect(() => this.updateIcon());
@@ -130,8 +133,23 @@ export class NgIcon {
   }
 
   private setSvg(svg: string): void {
-    this.elementRef.nativeElement.innerHTML = this.preProcessor(svg);
-    this.postProcessor(this.elementRef.nativeElement);
+    // remove the old element
+    if (this.svgElement) {
+      this.elementRef.nativeElement.removeChild(this.svgElement);
+    }
+
+    // if the svg is empty, don't insert anything
+    if (svg === '') {
+      return;
+    }
+
+    const template = document.createElement('template');
+    template.innerHTML = this.preProcessor(svg);
+    this.svgElement = template.content.firstElementChild as SVGElement;
+    this.postProcessor(this.svgElement);
+
+    // insert the element into the dom
+    this.elementRef.nativeElement.appendChild(this.svgElement);
   }
 
   /**

--- a/packages/core/src/lib/components/icon/icon.component.ts
+++ b/packages/core/src/lib/components/icon/icon.component.ts
@@ -6,6 +6,7 @@ import {
   inject,
   Injector,
   input,
+  OnDestroy,
   runInInjectionContext,
 } from '@angular/core';
 import type { IconName } from '../../components/icon/icon-name';
@@ -40,7 +41,7 @@ export type IconType = IconName | (string & {});
     '[style.color]': 'color()',
   },
 })
-export class NgIcon {
+export class NgIcon implements OnDestroy {
   /** Access the global icon config */
   private readonly config = injectNgIconConfig();
 
@@ -89,6 +90,10 @@ export class NgIcon {
   constructor() {
     // update the icon anytime the name or svg changes
     effect(() => this.updateIcon());
+  }
+
+  ngOnDestroy(): void {
+    this.svgElement = undefined;
   }
 
   private async updateIcon(): Promise<void> {

--- a/packages/core/src/lib/providers/features/csp.ts
+++ b/packages/core/src/lib/providers/features/csp.ts
@@ -6,7 +6,7 @@ import {
 } from './features';
 
 export type NgIconPreProcessor = (icon: string) => string;
-export type NgIconPostProcessor = (element: HTMLElement) => void;
+export type NgIconPostProcessor = (element: HTMLElement | SVGElement) => void;
 
 export const NgIconPreProcessorToken = new InjectionToken<NgIconPreProcessor>(
   'Ng Icon Pre Processor',
@@ -29,10 +29,12 @@ function preprocessIcon(icon: string): string {
   return icon.replace(/style\s*=/g, 'data-style=');
 }
 
-function postprocessIcon(element: HTMLElement): void {
+function postprocessIcon(element: HTMLElement | SVGElement): void {
   // find all elements with a data-style attribute and get the styles from it
   // and apply them to the element using the style property and remove the data-style attribute
-  const elements = element.querySelectorAll<HTMLElement>('[data-style]');
+  const elements = element.querySelectorAll<HTMLElement | SVGElement>(
+    '[data-style]',
+  );
 
   for (const element of Array.from(elements)) {
     const styles = element.getAttribute('data-style');


### PR DESCRIPTION
We were previously using `innerHTML`, which replaces the entire content with the SVG. This could be problematic when using things like the material badge component which appends the badge as a child. Prior to version 29 this did work, but only by coincidence rather than by design.

This should now selectively append and remove the svg element, retaining all other children

Fixes: #127