### PR TITLE
refactor: convert showBlurredNavbar to Signal for improved reactivity

### DIFF
--- a/apps/documentation/src/app/components/navbar/navbar.component.html
+++ b/apps/documentation/src/app/components/navbar/navbar.component.html
@@ -1,7 +1,7 @@
 <div
   class="fixed top-0 z-10 w-full animate-[navbar] transition-all duration-1000 before:absolute before:bottom-0 before:h-px before:w-full before:rounded-2xl before:bg-gradient-to-r before:from-transparent before:via-white/10 before:to-transparent before:backdrop-blur-sm"
   [ngClass]="{
-    'bg-black/5 backdrop-blur-sm': showBlurredNavbar,
+    'bg-black/5 backdrop-blur-sm': showBlurredNavbar(),
   }"
 >
   <div class="container mx-auto flex h-16 items-center justify-between px-4">

--- a/apps/documentation/src/app/components/navbar/navbar.component.ts
+++ b/apps/documentation/src/app/components/navbar/navbar.component.ts
@@ -1,9 +1,10 @@
 import { NgClass } from '@angular/common';
-import { Component, OnInit } from '@angular/core';
+import { Component, Signal } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { RouterLink } from '@angular/router';
 import { bootstrapGithub } from '@ng-icons/bootstrap-icons';
 import { NgIconComponent, provideIcons } from '@ng-icons/core';
-import { fromEvent } from 'rxjs';
+import { distinctUntilChanged, fromEvent, map } from 'rxjs';
 
 @Component({
   selector: 'app-navbar',
@@ -12,13 +13,16 @@ import { fromEvent } from 'rxjs';
   templateUrl: './navbar.component.html',
   styleUrls: ['./navbar.component.scss'],
 })
-export class NavbarComponent implements OnInit {
-  showBlurredNavbar = false;
+export class NavbarComponent {
+  public readonly showBlurredNavbar: Signal<boolean>;
 
-  ngOnInit(): void {
-    // monitor the scroll position and update the navbar accordingly
-    fromEvent(window, 'scroll').subscribe(() => {
-      this.showBlurredNavbar = window.scrollY > 0;
-    });
+  constructor() {
+    this.showBlurredNavbar = toSignal(
+      fromEvent(window, 'scroll').pipe(
+        map(() => window.scrollY > 0),
+        distinctUntilChanged(),
+      ),
+      { initialValue: false },
+    );
   }
 }


### PR DESCRIPTION
- Updated navbar component to use Angular's Signal for managing the blurred state based on scroll position.
- Replaced the ngOnInit lifecycle method with a constructor that initializes the Signal using fromEvent and distinctUntilChanged for better performance.