### PR TITLE
refactor: navbar template - removed ngClass + new control flow for routes

### DIFF
--- a/apps/documentation/src/app/components/navbar/navbar.component.html
+++ b/apps/documentation/src/app/components/navbar/navbar.component.html
@@ -1,8 +1,6 @@
 <div
   class="fixed top-0 z-10 w-full animate-[navbar] transition-all duration-1000 before:absolute before:bottom-0 before:h-px before:w-full before:rounded-2xl before:bg-gradient-to-r before:from-transparent before:via-white/10 before:to-transparent before:backdrop-blur-sm"
-  [ngClass]="{
-    'bg-black/5 backdrop-blur-sm': showBlurredNavbar(),
-  }"
+  [class]="showBlurredNavbar()"
 >
   <div class="container mx-auto flex h-16 items-center justify-between px-4">
     <img
@@ -19,27 +17,30 @@
       alt="Logo"
     />
 
-    <div class="flex">
-      <a
-        href="#"
-        class="inline-flex items-center rounded-md p-2 text-center text-sm text-white/80 outline-none transition-colors duration-150 hover:text-white focus-visible:ring-2 focus-visible:ring-white/50"
-        routerLink="/getting-started"
-        >Getting Started</a
-      >
-      <a
-        href="#"
-        class="inline-flex items-center rounded-md p-2 text-center text-sm text-white/80 outline-none transition-colors duration-150 hover:text-white focus-visible:ring-2 focus-visible:ring-white/50"
-        routerLink="/browse-icons"
-        >Browse Icons</a
-      >
+    @let NAV_CLASSES =
+      'inline-flex items-center rounded-md p-2 text-center text-white/80 outline-none transition-colors duration-150 hover:text-white focus-visible:ring-2 focus-visible:ring-white/50';
 
-      <a
-        href="https://github.com/ng-icons/ng-icons"
-        target="_blank"
-        class="ml-2 inline-flex items-center rounded-md p-2 text-center text-3xl text-white/80 outline-none transition-colors duration-150 hover:text-white focus-visible:ring-2 focus-visible:ring-white/50"
-      >
-        <ng-icon name="bootstrapGithub"></ng-icon>
-      </a>
+    <div class="flex">
+      @for (link of navLinks; track link.routerLink) {
+        @if (link.routerLink) {
+          <a
+            [href]="link.href"
+            [routerLink]="link.routerLink"
+            [target]="link.target"
+            [class]="NAV_CLASSES + ' ' + link.extraClass"
+          >
+            {{ link.label }}
+          </a>
+        } @else {
+          <a
+            [href]="link.href"
+            [target]="link.target"
+            [class]="NAV_CLASSES + ' ' + link.extraClass"
+          >
+            <ng-icon [name]="link.iconName"></ng-icon>
+          </a>
+        }
+      }
     </div>
   </div>
 </div>

--- a/apps/documentation/src/app/components/navbar/navbar.component.ts
+++ b/apps/documentation/src/app/components/navbar/navbar.component.ts
@@ -1,28 +1,29 @@
-import { NgClass } from '@angular/common';
 import { Component, Signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { RouterLink } from '@angular/router';
 import { bootstrapGithub } from '@ng-icons/bootstrap-icons';
 import { NgIconComponent, provideIcons } from '@ng-icons/core';
 import { distinctUntilChanged, fromEvent, map } from 'rxjs';
+import { NAV_LINKS } from '../../constants/nav-link.constant';
 
 @Component({
   selector: 'app-navbar',
-  imports: [NgIconComponent, RouterLink, RouterLink, NgClass],
+  imports: [NgIconComponent, RouterLink],
   providers: [provideIcons({ bootstrapGithub })],
   templateUrl: './navbar.component.html',
   styleUrls: ['./navbar.component.scss'],
 })
 export class NavbarComponent {
-  public readonly showBlurredNavbar: Signal<boolean>;
+  protected readonly showBlurredNavbar: Signal<string>;
+  protected readonly navLinks = NAV_LINKS;
 
   constructor() {
     this.showBlurredNavbar = toSignal(
       fromEvent(window, 'scroll').pipe(
-        map(() => window.scrollY > 0),
+        map(() => (window.scrollY > 0 ? 'bg-black/5 backdrop-blur-sm' : '')),
         distinctUntilChanged(),
       ),
-      { initialValue: false },
+      { initialValue: '' },
     );
   }
 }

--- a/apps/documentation/src/app/constants/nav-link.constant.ts
+++ b/apps/documentation/src/app/constants/nav-link.constant.ts
@@ -1,0 +1,25 @@
+import { NavLink } from '../models/nav-link.model';
+
+export const NAV_LINKS: NavLink[] = [
+  {
+    label: 'Getting Started',
+    routerLink: '/getting-started',
+    href: '#',
+    target: '_self',
+    extraClass: 'text-sm',
+  },
+  {
+    label: 'Browse Icons',
+    routerLink: '/browse-icons',
+    href: '#',
+    target: '_self',
+    extraClass: 'text-sm',
+  },
+  {
+    routerLink: undefined,
+    href: 'https://github.com/ng-icons/ng-icons',
+    target: '_blank',
+    extraClass: 'ml-2 text-3xl',
+    iconName: 'bootstrapGithub',
+  },
+];

--- a/apps/documentation/src/app/models/nav-link.model.ts
+++ b/apps/documentation/src/app/models/nav-link.model.ts
@@ -1,0 +1,8 @@
+export interface NavLink {
+  href: string;
+  target: '_self' | '_blank';
+  extraClass: string;
+  label?: string;
+  routerLink?: string;
+  iconName?: string;
+}


### PR DESCRIPTION
### Changes Made in Navbar Refactoring :

- Removed NgClass and it's import, replaced with [class] syntax as ngClass is gonna be soft deprecated.
- Removed the duplicated import of RouterLink in the component.
- Updated the navbar template with new control flow syntax and used @ let for common classes in navLinks, which reduces the code duplication.
- Created two new files, one for navlinks interface and one for navlinks constant.

Linting has been performed with pnpm lint.
Testing has been performed with pnpm test.

The changes have been tested in local against the https://ng-icons.github.io/ng-icons/#/ 
and the navigations are working as expected.