### PR TITLE
refactor: signal queries in fade-in directives

### DIFF
--- a/apps/documentation/src/app/directives/fade-in/fade-in-container.directive.ts
+++ b/apps/documentation/src/app/directives/fade-in/fade-in-container.directive.ts
@@ -1,22 +1,18 @@
-import {
-  AfterContentInit,
-  ContentChildren,
-  Directive,
-  QueryList,
-} from '@angular/core';
+import { contentChildren, Directive, effect } from '@angular/core';
 import { FadeInDirective } from './fade-in.directive';
 
 @Directive({
   selector: '[appFadeInContainer]',
   standalone: true,
 })
-export class FadeInContainerDirective implements AfterContentInit {
-  @ContentChildren(FadeInDirective)
-  fadeInDirectives?: QueryList<FadeInDirective>;
+export class FadeInContainerDirective {
+  fadeInDirectives = contentChildren<FadeInDirective>(FadeInDirective);
 
-  ngAfterContentInit(): void {
-    this.fadeInDirectives?.forEach((directive, index) => {
-      directive.delay = (index + 1) * 50;
+  constructor() {
+    effect(() => {
+      this.fadeInDirectives().forEach((directive, index) => {
+        directive.delay.set((index + 1) * 50);
+      });
     });
   }
 }

--- a/apps/documentation/src/app/directives/fade-in/fade-in.directive.ts
+++ b/apps/documentation/src/app/directives/fade-in/fade-in.directive.ts
@@ -1,13 +1,13 @@
-import { Directive, HostBinding } from '@angular/core';
+import { Directive, signal } from '@angular/core';
 
 @Directive({
   selector: '[appFadeIn]',
   standalone: true,
   host: {
     '[class.fade-in]': 'true',
+    '[style.animation-delay.ms]': 'delay()',
   },
 })
 export class FadeInDirective {
-  @HostBinding('style.animation-delay.ms')
-  delay = 0;
+  delay = signal(0);
 }


### PR DESCRIPTION
### Changes made in directives refactor: 

- Updated @ HostBinding style to be in Directives host property + delay property as a signal.
- Replaced @ ContentChildren (decorator queries) with contentChildren (signal queries).
- Replaced AfterContentInit hook with effect() in the injection context for reading the contentChildren

Linted with pnpm lint
Tested with pnpm test

The Changes are tested in local against https://ng-icons.github.io/ng-icons/#/
and it is working as expected.