### PR TITLE
feat(documentation): add iconset active to query params 

### DIFF
--- a/apps/documentation/src/app/browse-icons/browse-icons.component.html
+++ b/apps/documentation/src/app/browse-icons/browse-icons.component.html
@@ -15,8 +15,8 @@
       <div
         class="iconset-card"
         [class.active]="iconset === activeIconset()"
-        (click)="loadIconset(iconset)"
-        (keydown.enter)="loadIconset(iconset)"
+        (click)="setIconset(iconset)"
+        (keydown.enter)="setIconset(iconset)"
         tabindex="0"
       >
         <ng-icon [name]="iconset.icon" />


### PR DESCRIPTION
### Add Icon Set Parameter to URL Query String

Hi 👋,
I'd like to propose an enhancement that would improve the user experience.

**Problem**
Currently, when users select an icon set, the selection is not persisted in the URL. This means:
- Users must manually select their preferred icon set on every visit
- Bookmarking the page doesn't preserve the icon set selection as well as sharing links to specific icon set is not possible

As a frequent user of this webpage, I find myself repeatedly selecting the same icon set every time I visit.

**Solution**
Add the icon query parameter to the URL when an icon set is selected. The application now: appends the selected icon set to the URL query string (e.g., ?iconset=faFontAwesome) and automatically loads the corresponding icon set when the page loads with an icon parameter.

Looking forward to your feedback!
