### PR TITLE
ci: add release workflow with npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,84 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version bump type'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Upgrade npm
+        run: npm install -g npm@11.5.1
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Version
+        run: pnpm exec nx release version ${{ inputs.version }}
+
+      - name: Compile packages
+        run: pnpm run compile
+
+      - name: Publish to npm
+        run: pnpm exec nx release publish
+
+      - name: Changelog
+        run: |
+          VERSION=$(node -p "require('./packages/core/package.json').version")
+          pnpm exec nx release changelog ${VERSION} --create-release=github
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push to main
+        run: git push origin HEAD:main --follow-tags --no-verify
+
+      - name: Release Summary
+        run: |
+          VERSION=$(node -p "require('./packages/core/package.json').version")
+          echo "## 🚀 Release Complete" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Version:** v${VERSION}" >> $GITHUB_STEP_SUMMARY
+          echo "**Type:** ${{ inputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "✅ Versions bumped" >> $GITHUB_STEP_SUMMARY
+          echo "✅ Packages compiled" >> $GITHUB_STEP_SUMMARY
+          echo "✅ Published to npm" >> $GITHUB_STEP_SUMMARY
+          echo "✅ Changelog updated" >> $GITHUB_STEP_SUMMARY
+          echo "✅ GitHub Release created" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Adds a manually-triggered GitHub Actions workflow that mirrors the
existing `pnpm run publish` chain (version -> compile -> publish ->
changelog) and uses OIDC trusted publishing (id-token: write, npm
>= 11.5.1) so no NPM_TOKEN is needed. Generates a GitHub Release
via `nx release changelog --create-release=github` and pushes the
version commit and tag back to main.