### PR TITLE
fix(lobe-icons): remove custom release config blocking nx release version

### DIFF
--- a/packages/lobe-icons/project.json
+++ b/packages/lobe-icons/project.json
@@ -4,13 +4,6 @@
   "sourceRoot": "packages/lobe-icons/src",
   "prefix": "ng",
   "projectType": "library",
-  "release": {
-    "version": {
-      "manifestRootsToUpdate": ["dist/{projectRoot}"],
-      "currentVersionResolver": "git-tag",
-      "fallbackCurrentVersionResolver": "disk"
-    }
-  },
   "tags": [],
   "targets": {
     "build": {


### PR DESCRIPTION
## Summary
- Drop the `release.version.manifestRootsToUpdate` override on `lobe-icons` that pointed at `dist/{projectRoot}`. That directory doesn't exist when `nx release version` runs (the `publish` script builds *after* versioning), so Nx aborts with "does not have a package.json file available in dist/packages/lobe-icons/".
- With the override gone, `lobe-icons` uses the default manifest resolution like every other package in the workspace (updating `packages/lobe-icons/package.json` directly).

## Test plan
- [ ] `pnpm nx release version --dry-run` completes without the missing-manifest error for `lobe-icons`
- [ ] `pnpm nx release changelog --dry-run` runs cleanly against the same version bump
- [ ] Full `pnpm run publish` flow (version → changelog → compile → publish) works end-to-end in CI

https://claude.ai/code/session_01P46ZRN7KzeNqFyD1AdxMSv