### PR TITLE
fix: add repository field to schematics and material-symbols packages

### DIFF
--- a/packages/material-symbols/package.json
+++ b/packages/material-symbols/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@ng-icons/material-symbols",
   "version": "33.0.0",
+  "repository": {
+    "url": "https://github.com/ng-icons/ng-icons"
+  },
   "peerDependencies": {
     "@ng-icons/core": "33.0.0"
   },

--- a/packages/schematics/package.json
+++ b/packages/schematics/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@ng-icons/schematics",
   "version": "33.0.0",
+  "repository": {
+    "url": "https://github.com/ng-icons/ng-icons"
+  },
   "main": "src/index.js",
   "generators": "./generators.json",
   "executors": "./executors.json",


### PR DESCRIPTION
Sigstore provenance validation on npm publish fails for
@ng-icons/schematics and @ng-icons/material-symbols because their
package.json files are missing the repository field. The field is
required for npm to validate that the package is being published from
the expected GitHub repository.