### PR TITLE
fix: correct package versions and commit release changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Commit release changes
+        run: |
+          VERSION=$(node -p "require('./packages/core/package.json').version")
+          git add -A
+          git commit -m "chore(release): publish ${VERSION}"
+
       - name: Push to main
         run: git push origin HEAD:main --follow-tags --no-verify
 

--- a/nx.json
+++ b/nx.json
@@ -104,7 +104,10 @@
   "nxCloudAccessToken": "ZTU5Nzk3NjQtZjUzMC00YzA1LWE3MGItMjRiNmFiOWFhYTllfHJlYWQ=",
   "defaultBase": "origin/main",
   "release": {
-    "projectsRelationship": "fixed"
+    "projectsRelationship": "fixed",
+    "version": {
+      "currentVersionResolver": "registry"
+    }
   },
   "tui": {
     "enabled": false

--- a/nx.json
+++ b/nx.json
@@ -104,10 +104,7 @@
   "nxCloudAccessToken": "ZTU5Nzk3NjQtZjUzMC00YzA1LWE3MGItMjRiNmFiOWFhYTllfHJlYWQ=",
   "defaultBase": "origin/main",
   "release": {
-    "projectsRelationship": "fixed",
-    "version": {
-      "currentVersionResolver": "registry"
-    }
+    "projectsRelationship": "fixed"
   },
   "tui": {
     "enabled": false

--- a/packages/akar-icons/package.json
+++ b/packages/akar-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-icons/akar-icons",
-  "version": "33.0.0",
+  "version": "33.2.0",
   "license": "MIT",
   "repository": {
     "url": "https://github.com/ng-icons/ng-icons"

--- a/packages/bootstrap-icons/package.json
+++ b/packages/bootstrap-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-icons/bootstrap-icons",
-  "version": "33.0.0",
+  "version": "33.2.0",
   "license": "MIT",
   "repository": {
     "url": "https://github.com/ng-icons/ng-icons"

--- a/packages/boxicons/package.json
+++ b/packages/boxicons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-icons/boxicons",
-  "version": "33.0.0",
+  "version": "33.2.0",
   "sideEffects": false,
   "license": "MIT",
   "repository": {

--- a/packages/circum-icons/package.json
+++ b/packages/circum-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-icons/circum-icons",
-  "version": "33.0.0",
+  "version": "33.2.0",
   "license": "MPL-2.0",
   "repository": {
     "url": "https://github.com/ng-icons/ng-icons"

--- a/packages/coolicons/package.json
+++ b/packages/coolicons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-icons/coolicons",
-  "version": "33.0.0",
+  "version": "33.2.0",
   "repository": {
     "url": "https://github.com/ng-icons/ng-icons"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-icons/core",
-  "version": "33.0.0",
+  "version": "33.2.0",
   "license": "MIT",
   "keywords": [
     "angular",

--- a/packages/cryptocurrency-icons/package.json
+++ b/packages/cryptocurrency-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-icons/cryptocurrency-icons",
-  "version": "33.0.0",
+  "version": "33.2.0",
   "license": "CC0-1.0",
   "repository": {
     "url": "https://github.com/ng-icons/ng-icons"

--- a/packages/css-gg/package.json
+++ b/packages/css-gg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-icons/css.gg",
-  "version": "33.0.0",
+  "version": "33.2.0",
   "license": "MIT",
   "repository": {
     "url": "https://github.com/ng-icons/ng-icons"

--- a/packages/devicon/package.json
+++ b/packages/devicon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-icons/devicon",
-  "version": "33.0.0",
+  "version": "33.2.0",
   "sideEffects": false,
   "license": "MIT",
   "repository": {

--- a/packages/dripicons/package.json
+++ b/packages/dripicons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-icons/dripicons",
-  "version": "33.0.0",
+  "version": "33.2.0",
   "license": "CC-BY-SA-4.0",
   "repository": {
     "url": "https://github.com/ng-icons/ng-icons"

--- a/packages/feather-icons/package.json
+++ b/packages/feather-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-icons/feather-icons",
-  "version": "33.0.0",
+  "version": "33.2.0",
   "repository": {
     "url": "https://github.com/ng-icons/ng-icons"
   },

--- a/packages/flag-icons/package.json
+++ b/packages/flag-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-icons/flag-icons",
-  "version": "33.0.0",
+  "version": "33.2.0",
   "sideEffects": false,
   "license": "MIT",
   "repository": {

--- a/packages/font-awesome/package.json
+++ b/packages/font-awesome/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-icons/font-awesome",
-  "version": "33.0.0",
+  "version": "33.2.0",
   "sideEffects": false,
   "license": "CC BY 4.0",
   "repository": {

--- a/packages/game-icons/package.json
+++ b/packages/game-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-icons/game-icons",
-  "version": "33.0.0",
+  "version": "33.2.0",
   "sideEffects": false,
   "license": "CC-BY-3.0",
   "repository": {

--- a/packages/heroicons/package.json
+++ b/packages/heroicons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-icons/heroicons",
-  "version": "33.0.0",
+  "version": "33.2.0",
   "license": "MIT",
   "repository": {
     "url": "https://github.com/ng-icons/ng-icons"

--- a/packages/huge-icons/package.json
+++ b/packages/huge-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-icons/huge-icons",
-  "version": "33.0.0",
+  "version": "33.2.0",
   "sideEffects": false,
   "license": "CC0-1.0",
   "repository": {

--- a/packages/iconoir/package.json
+++ b/packages/iconoir/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-icons/iconoir",
-  "version": "33.0.0",
+  "version": "33.2.0",
   "license": "MIT",
   "repository": {
     "url": "https://github.com/ng-icons/ng-icons"

--- a/packages/iconsax/package.json
+++ b/packages/iconsax/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-icons/iconsax",
-  "version": "33.0.0",
+  "version": "33.2.0",
   "sideEffects": false,
   "license": "SEE LICENSE IN https://iconsax.io/#license",
   "repository": {

--- a/packages/ionicons/package.json
+++ b/packages/ionicons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-icons/ionicons",
-  "version": "33.0.0",
+  "version": "33.2.0",
   "license": "MIT",
   "repository": {
     "url": "https://github.com/ng-icons/ng-icons"

--- a/packages/jam-icons/package.json
+++ b/packages/jam-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-icons/jam-icons",
-  "version": "33.0.0",
+  "version": "33.2.0",
   "license": "MIT",
   "repository": {
     "url": "https://github.com/ng-icons/ng-icons"

--- a/packages/lets-icons/package.json
+++ b/packages/lets-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-icons/lets-icons",
-  "version": "33.0.0",
+  "version": "33.2.0",
   "repository": {
     "url": "https://github.com/ng-icons/ng-icons"
   },

--- a/packages/lobe-icons/package.json
+++ b/packages/lobe-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-icons/lobe-icons",
-  "version": "33.0.0",
+  "version": "33.2.0",
   "sideEffects": false,
   "license": "MIT",
   "repository": {

--- a/packages/lucide/package.json
+++ b/packages/lucide/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-icons/lucide",
-  "version": "33.0.0",
+  "version": "33.2.0",
   "dependencies": {},
   "sideEffects": false,
   "license": "ISC",

--- a/packages/material-file-icons/package.json
+++ b/packages/material-file-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-icons/material-file-icons",
-  "version": "33.0.0",
+  "version": "33.2.0",
   "repository": {
     "url": "https://github.com/ng-icons/ng-icons"
   },

--- a/packages/material-icons/package.json
+++ b/packages/material-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-icons/material-icons",
-  "version": "33.0.0",
+  "version": "33.2.0",
   "license": "MIT",
   "repository": {
     "url": "https://github.com/ng-icons/ng-icons"

--- a/packages/material-symbols/package.json
+++ b/packages/material-symbols/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-icons/material-symbols",
-  "version": "33.0.0",
+  "version": "33.2.0",
   "repository": {
     "url": "https://github.com/ng-icons/ng-icons"
   },

--- a/packages/mono-icons/package.json
+++ b/packages/mono-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-icons/mono-icons",
-  "version": "33.0.0",
+  "version": "33.2.0",
   "sideEffects": false,
   "license": "MIT",
   "repository": {

--- a/packages/mynaui/package.json
+++ b/packages/mynaui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-icons/mynaui",
-  "version": "33.0.0",
+  "version": "33.2.0",
   "sideEffects": false,
   "license": "MIT",
   "repository": {

--- a/packages/octicons/package.json
+++ b/packages/octicons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-icons/octicons",
-  "version": "33.0.0",
+  "version": "33.2.0",
   "license": "MIT",
   "repository": {
     "url": "https://github.com/ng-icons/ng-icons"

--- a/packages/phosphor-icons/package.json
+++ b/packages/phosphor-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-icons/phosphor-icons",
-  "version": "33.0.0",
+  "version": "33.2.0",
   "sideEffects": false,
   "license": "MIT",
   "repository": {

--- a/packages/radix-icons/package.json
+++ b/packages/radix-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-icons/radix-icons",
-  "version": "33.0.0",
+  "version": "33.2.0",
   "repository": {
     "url": "https://github.com/ng-icons/ng-icons"
   },

--- a/packages/remixicon/package.json
+++ b/packages/remixicon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-icons/remixicon",
-  "version": "33.0.0",
+  "version": "33.2.0",
   "sideEffects": false,
   "license": "Apache",
   "repository": {

--- a/packages/schematics/package.json
+++ b/packages/schematics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-icons/schematics",
-  "version": "33.0.0",
+  "version": "33.2.0",
   "repository": {
     "url": "https://github.com/ng-icons/ng-icons"
   },

--- a/packages/simple-icons/package.json
+++ b/packages/simple-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-icons/simple-icons",
-  "version": "33.0.0",
+  "version": "33.2.0",
   "license": "CC0-1.0",
   "repository": {
     "url": "https://github.com/ng-icons/ng-icons"

--- a/packages/solar-icons/package.json
+++ b/packages/solar-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-icons/solar-icons",
-  "version": "33.0.0",
+  "version": "33.2.0",
   "sideEffects": false,
   "license": "CC-BY-4.0",
   "repository": {

--- a/packages/svgl/package.json
+++ b/packages/svgl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-icons/svgl",
-  "version": "33.0.0",
+  "version": "33.2.0",
   "sideEffects": false,
   "license": "MIT",
   "repository": {

--- a/packages/tabler-icons/package.json
+++ b/packages/tabler-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-icons/tabler-icons",
-  "version": "33.0.0",
+  "version": "33.2.0",
   "license": "MIT",
   "repository": {
     "url": "https://github.com/ng-icons/ng-icons"

--- a/packages/tdesign-icons/package.json
+++ b/packages/tdesign-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-icons/tdesign-icons",
-  "version": "33.0.0",
+  "version": "33.2.0",
   "sideEffects": false,
   "license": "MIT",
   "repository": {

--- a/packages/typicons/package.json
+++ b/packages/typicons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-icons/typicons",
-  "version": "33.0.0",
+  "version": "33.2.0",
   "license": "CC-BY-SA-4.0",
   "repository": {
     "url": "https://github.com/ng-icons/ng-icons"

--- a/packages/ux-aspects/package.json
+++ b/packages/ux-aspects/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-icons/ux-aspects",
-  "version": "33.0.0",
+  "version": "33.2.0",
   "license": "Apache-2.0",
   "repository": {
     "url": "https://github.com/ng-icons/ng-icons"


### PR DESCRIPTION
## Summary

- **Add a "Commit release changes" step** to the release workflow so that version bumps and changelog updates are committed and pushed back to main after each release
- **Update all 40 package.json files from `33.0.0` to `33.2.0`** to match the actual latest correctly-published version on npm

### Root cause

The release workflow ran `nx release version` which updates `package.json` files on disk, but never committed those changes. The `git push` at the end pushed the unchanged HEAD, so `package.json` on main stayed at `33.0.0` forever. This caused the latest release to bump from `33.0.0 → 33.0.1` instead of `33.2.0 → 33.2.1`.

### Manual follow-up needed

The npm `latest` dist-tag is currently pointing at `33.0.1` instead of `33.2.0` (npm moved it because `33.0.1` was published most recently). This should be fixed for each package:

```
npm dist-tag add @ng-icons/core@33.2.0 latest
```

## Test plan

- [ ] Verify the workflow YAML is valid
- [ ] Run a release with `patch` and confirm the version bumps from `33.2.0 → 33.2.1`
- [ ] Confirm the commit with `chore(release): publish 33.2.1` appears on main after the release

https://claude.ai/code/session_01SdgkQRC4ireNsgC5LCq5gv