### PR TITLE
fix(docs): disable Google Fonts inlining in production build

### DIFF
--- a/apps/documentation/project.json
+++ b/apps/documentation/project.json
@@ -28,6 +28,9 @@
       "configurations": {
         "production": {
           "budgets": [],
+          "optimization": {
+            "fonts": false
+          },
           "fileReplacements": [
             {
               "replace": "apps/documentation/src/environments/environment.ts",


### PR DESCRIPTION
Angular 21 inlines external fonts during production builds by default.
The Google Fonts request returns 403 in CI, breaking the build. Disable
font inlining so the font is loaded at runtime via the existing link tag
in index.html instead.

https://claude.ai/code/session_01SoB9548TVz3ZXizaDj7fLE