### PR TITLE
fix(core): apply strokeWidth on root svg when CSP is enabled

### DIFF
--- a/packages/core/src/lib/components/icon/icon.component.spec.ts
+++ b/packages/core/src/lib/components/icon/icon.component.spec.ts
@@ -8,6 +8,8 @@ import {
 } from '@ng-icons/feather-icons';
 import { vi } from 'vitest';
 import { NgIconsModule } from '../../icon.module';
+import { withContentSecurityPolicy } from '../../providers/features/csp';
+import { provideNgIconsConfig } from '../../providers/icon-config.provider';
 import {
   provideNgIconLoader,
   withCaching,
@@ -345,5 +347,57 @@ describe('Custom loader with caching', () => {
     await new Promise(resolve => setTimeout(resolve, 0));
 
     expect(loaderSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+// regression tests for https://github.com/ng-icons/ng-icons/issues/246
+// with the content security policy feature enabled, inline styles are renamed to
+// data-style during pre-processing and must be restored during post-processing -
+// including the style on the root svg element itself, not just its descendants.
+describe('Icon with content security policy', () => {
+  let fixture: ComponentFixture<NgIcon>;
+  let nativeElement: HTMLElement;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [NgIcon],
+      providers: [
+        provideIcons({ featherAlertCircle }),
+        provideNgIconsConfig({}, withContentSecurityPolicy()),
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(NgIcon);
+    fixture.componentRef.setInput('name', 'featherAlertCircle');
+    fixture.detectChanges();
+    nativeElement = fixture.nativeElement;
+  });
+
+  afterEach(() => {
+    TestBed.resetTestingModule();
+  });
+
+  it('should restore the inline style on the root svg element', () => {
+    const svg = nativeElement.querySelector('svg')!;
+
+    // the data-style attribute used to dodge the CSP must have been removed
+    expect(svg.hasAttribute('data-style')).toBe(false);
+    // and the style it carried must have been applied to the element
+    expect(svg.style.strokeWidth).toBe('var(--ng-icon__stroke-width, 2)');
+  });
+
+  it('should apply the stroke width to the rendered svg', () => {
+    const svg = nativeElement.querySelector('svg')!;
+    const child = svg.querySelector('circle')!;
+
+    // defaults to the fallback baked into the svg when unset
+    expect(getComputedStyle(svg).strokeWidth).toBe('2px');
+    expect(getComputedStyle(child).strokeWidth).toBe('2px');
+
+    fixture.componentRef.setInput('strokeWidth', 4);
+    fixture.detectChanges();
+
+    expect(getComputedStyle(svg).strokeWidth).toBe('4px');
+    expect(getComputedStyle(child).strokeWidth).toBe('4px');
   });
 });

--- a/packages/core/src/lib/providers/features/csp.ts
+++ b/packages/core/src/lib/providers/features/csp.ts
@@ -32,12 +32,17 @@ function preprocessIcon(icon: string): string {
 
 function postprocessIcon(element: HTMLElement | SVGElement): void {
   // find all elements with a data-style attribute and get the styles from it
-  // and apply them to the element using the style property and remove the data-style attribute
-  const elements = element.querySelectorAll<HTMLElement | SVGElement>(
-    '[data-style]',
-  );
+  // and apply them to the element using the style property and remove the data-style attribute.
+  // the root element is included as querySelectorAll only matches descendants, but the
+  // style on the root svg (e.g. the stroke-width) must be restored too.
+  const elements = [
+    ...(element.hasAttribute('data-style') ? [element] : []),
+    ...Array.from(
+      element.querySelectorAll<HTMLElement | SVGElement>('[data-style]'),
+    ),
+  ];
 
-  for (const element of Array.from(elements)) {
+  for (const element of elements) {
     const styles = element.getAttribute('data-style');
 
     styles?.split(';').forEach(style => {


### PR DESCRIPTION
## Summary

Fixes #246 - `strokeWidth` (and any other inline style on the root `<svg>`) had no effect when `withContentSecurityPolicy()` was enabled.

## Root cause

Every icon SVG carries its stroke-width as an inline style on the **root** `<svg>` element:

```html
<svg ... style="stroke-width:var(--ng-icon__stroke-width, 2)">
```

With CSP enabled, the pre-processor renames `style=` to `data-style=` to avoid being blocked by the policy, and the post-processor is supposed to restore it. But the post-processor only scanned **descendants**:

```js
const elements = element.querySelectorAll('[data-style]');
```

`querySelectorAll` never matches the element it is called on, so the root `<svg>`'s `data-style` was never converted back to a real `style` attribute. The stroke-width was left inert as `data-style`, which is exactly the leftover attribute reported in the issue.

## Fix

`postprocessIcon` now includes the root element itself when it carries `data-style`, in addition to its descendants.

## Testing

Added a TDD `Icon with content security policy` test suite to `icon.component.spec.ts`:
- asserts the root svg's `data-style` is restored to a real `style` attribute
- asserts the stroke width reaches the rendered svg and its children at both the default and an explicitly set value

All 37 core tests pass and lint is clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores inline styles on the root SVG when CSP is enabled so `strokeWidth` and other root styles work with `withContentSecurityPolicy()`. Fixes #246.

- **Bug Fixes**
  - CSP postprocessor now restores `style` from `data-style` on the root element, not just descendants.
  - Added regression tests to confirm the root style is restored and the computed stroke width applies to the SVG and its children for default and custom values.

<sup>Written for commit b0ba797670c446f93ca9273cefada4b6c02b0b0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-icons/ng-icons/pull/250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

