### PR TITLE
ci(deploy): install playwright chromium before running tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,9 @@ jobs:
           node-version: 20
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
+
+      - run: pnpm exec playwright install chromium --with-deps
+
       - uses: nrwl/nx-set-shas@v4
 
       - run: pnpm exec nx generate @ng-icons/workspace-plugin:svg-to-ts


### PR DESCRIPTION
## Problem

The `deploy` workflow was failing on `main` (e.g. [run 29021144060](https://github.com/ng-icons/ng-icons/actions/runs/29021144060)) at the `core:test` task:

```
Error: browserType.launch: Executable doesn't exist at
/home/runner/.cache/ms-playwright/chromium_headless_shell-1194/chrome-linux/headless_shell
```

`core:test` runs a `@vitest/browser-playwright` browser test that needs Chromium. `ci.yml` installs it, but `deploy.yml` did not - so the same commit passed CI but failed deploy.

## Fix

Add the same `pnpm exec playwright install chromium --with-deps` step to `deploy.yml` before the nx tasks run, matching `ci.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QkQoiuQvZhKxFnAPkvCCRS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix deploy workflow failures by installing Playwright Chromium before running browser tests. This ensures deploy runs match CI and stop failing due to a missing browser.

- **Bug Fixes**
  - Add `pnpm exec playwright install chromium --with-deps` to `.github/workflows/deploy.yml` before Nx tasks (mirrors `ci.yml`).

<sup>Written for commit c4ad84a2e46deedb871b07e42851a80c77750f00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-icons/ng-icons/pull/257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

