### PR TITLE
fix: unblock release (peer-dep ranges) and remove broken nx distribution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,6 @@ jobs:
 
       - uses: nrwl/nx-set-shas@v4
 
-      # Distribute affected tasks across 3 Nx Agents (Nx Cloud's minimum).
-      - run: pnpm exec nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="lint,test,build"
-
       # Regenerate the icon sets, then fail if the committed output is stale.
       # Generation is deterministic (all sources are pinned), so any diff means
       # someone bumped a source or hand-edited generated files without regenerating.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,9 +44,6 @@ jobs:
 
       - uses: nrwl/nx-set-shas@v4
 
-      # Distribute affected tasks across 3 Nx Agents (Nx Cloud's minimum).
-      - run: pnpm exec nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="lint,test,build"
-
       - run: pnpm exec nx generate @ng-icons/workspace-plugin:svg-to-ts
       - run: pnpm exec nx generate @ng-icons/workspace-plugin:update-readmes
       - run: pnpm exec nx-cloud record -- nx format:check

--- a/nx.json
+++ b/nx.json
@@ -105,6 +105,9 @@
   "defaultBase": "origin/main",
   "release": {
     "projectsRelationship": "fixed",
+    "version": {
+      "preserveMatchingDependencyRanges": false
+    },
     "changelog": {
       "workspaceChangelog": {
         "createRelease": "github"


### PR DESCRIPTION
Two related CI/release fixes.

## 1. Release: auto-update peer dependency ranges (`nx.json`)

The **Release** workflow failed on a major bump (33.4.0 → 34.0.0):

```
NX  "preserveMatchingDependencyRanges" is enabled ... new version "^34.0.0" is
outside the current range for "@ng-icons/core" in packages/material-symbols/package.json
```

`@ng-icons/material-symbols` is the only icon package that imports `@ng-icons/core` (it re-exports an `NgGlyphset`), so it legitimately declares it as a peer. Nx 22 flipped `preserveMatchingDependencyRanges` to `true` by default, which makes nx refuse to widen the peer range on a major bump. Setting it back to `false` restores the pre-22 behaviour: nx auto-updates the range. Verified with `nx release version major --dry-run` (`^33.0.0` → `^34.0.0`, no error).

## 2. Remove Nx Agents distribution (`ci.yml`, `deploy.yml`)

Distribution (added in #259) broke `main` CI: `core:test` is a Playwright browser test, and under distribution it runs on an Nx Agent that has no browser (`playwright install` runs only on the orchestrator). Fixing that properly needs a custom agent launch template - not worth it for this workspace (small tasks, one browser test, Nx's 3-agent minimum). Remote caching (kept, via the read-write token) was the real win. `nx affected` now runs on the single runner, which has the browser.