### PR TITLE
ci: remove nx agents distribution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,6 @@ jobs:
 
       - uses: nrwl/nx-set-shas@v4
 
-      # Distribute affected tasks across 3 Nx Agents (Nx Cloud's minimum).
-      - run: pnpm exec nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="lint,test,build"
-
       # Regenerate the icon sets, then fail if the committed output is stale.
       # Generation is deterministic (all sources are pinned), so any diff means
       # someone bumped a source or hand-edited generated files without regenerating.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,9 +44,6 @@ jobs:
 
       - uses: nrwl/nx-set-shas@v4
 
-      # Distribute affected tasks across 3 Nx Agents (Nx Cloud's minimum).
-      - run: pnpm exec nx-cloud start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="lint,test,build"
-
       - run: pnpm exec nx generate @ng-icons/workspace-plugin:svg-to-ts
       - run: pnpm exec nx generate @ng-icons/workspace-plugin:update-readmes
       - run: pnpm exec nx-cloud record -- nx format:check


### PR DESCRIPTION
## Why

Enabling Nx Agents distribution (#259) broke CI on `main`. `core:test` is a Playwright browser test; with distribution it runs on an Nx Agent, but `playwright install` runs on the orchestrator runner, so the agent has no browser:

```
Error: browserType.launch: Executable doesn't exist at
/home/workflows/.cache/ms-playwright/...
```

Fixing this properly would need a custom Nx Agents launch template that installs Chromium on every agent. For this workspace - many small, seconds-long tasks, a single browser test, and Nx Cloud's 3-agent minimum - distribution's payoff doesn't justify that maintenance. Remote caching (kept) was always the larger win.

## Change

- Remove the `nx-cloud start-ci-run --distribute-on=...` step from `ci.yml` and `deploy.yml`.
- Keep everything else from the CI-speedup work: the read-write `NX_CLOUD_ACCESS_TOKEN` for cache writes on protected branches, Playwright caching, the icon drift check, and the faster generator.

`nx affected -t lint test build` now runs on the single runner, which has the browser installed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable Nx Agents distribution in CI to fix Playwright tests failing on agents without browsers by removing `pnpm exec nx-cloud start-ci-run --distribute-on=...` from `ci.yml` and `deploy.yml`. `lint`, `test`, and `build` now run on the single runner with Playwright installed; remote caching via `nx-cloud` remains enabled.

<sup>Written for commit 7cea53d6e8bc8f37c05c4b353ce3ce338aad0c05. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-icons/ng-icons/pull/261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

