### PR TITLE
fix(core): repair ng-add packaging

### DIFF
--- a/packages/core/eslint.config.js
+++ b/packages/core/eslint.config.js
@@ -31,6 +31,12 @@ module.exports = [
     },
     languageOptions: { parser: require('jsonc-eslint-parser') },
   },
+  {
+    // Not a package: it only marks the schematics output as CommonJS, since the
+    // published package root is "type": "module" as of ng-packagr 22.
+    files: ['**/schematics/package.json'],
+    rules: { '@nx/dependency-checks': 'off' },
+  },
   ...nx.configs['flat/angular'],
   ...nx.configs['flat/angular-template'],
   {

--- a/packages/core/project.json
+++ b/packages/core/project.json
@@ -37,7 +37,7 @@
       "options": {
         "commands": [
           "npx tsc -p packages/core/schematics/tsconfig.json",
-          "cp packages/core/schematics/**/*.json dist/packages/core/schematics/"
+          "node packages/core/schematics/verify-package.mjs"
         ],
         "parallel": false
       }

--- a/packages/core/schematics/collection.json
+++ b/packages/core/schematics/collection.json
@@ -3,7 +3,7 @@
   "schematics": {
     "ng-add": {
       "description": "Add ng-icons to an Angular project",
-      "factory": "./schematics/ng-add/index#ngAdd",
+      "factory": "./ng-add/index#ngAdd",
       "schema": "./ng-add/schema.json"
     }
   }

--- a/packages/core/schematics/ng-add/schema.json
+++ b/packages/core/schematics/ng-add/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/schema",
-  "id": "NgIconsAdd",
+  "$id": "NgIconsAdd",
   "title": "ng-icons ng-add schematic",
   "description": "Add ng-icons to an Angular project and optionally install iconsets",
   "type": "object",

--- a/packages/core/schematics/package.json
+++ b/packages/core/schematics/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/packages/core/schematics/verify-package.mjs
+++ b/packages/core/schematics/verify-package.mjs
@@ -1,0 +1,43 @@
+// Verifies the *packaged* schematics actually load. The unit tests import the
+// factory directly, so they cannot catch packaging faults: a wrong factory path
+// in collection.json, CommonJS output under a "type": "module" package, or a
+// schema the Angular CLI's validator rejects. All three shipped broken at some
+// point, so this runs as part of build-schematics and fails the build instead.
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, resolve } from 'node:path';
+
+const dist = 'dist/packages/core/schematics';
+const require = createRequire(import.meta.url);
+const read = path => JSON.parse(readFileSync(path, 'utf-8'));
+
+const collectionPath = resolve(dist, 'collection.json');
+const collection = read(collectionPath);
+
+for (const [name, entry] of Object.entries(collection.schematics)) {
+  const [factoryPath, exportName] = entry.factory.split('#');
+
+  // Resolves relative to collection.json, exactly as the schematics engine does.
+  const resolved = require.resolve(
+    resolve(dirname(collectionPath), factoryPath),
+  );
+  const loaded = require(resolved);
+
+  if (typeof loaded[exportName] !== 'function') {
+    throw new Error(
+      `${name}: ${entry.factory} did not export a function named "${exportName}"`,
+    );
+  }
+
+  // The CLI validator rejects draft-04 "id" in favour of "$id".
+  const schema = read(resolve(dirname(collectionPath), entry.schema));
+  if ('id' in schema) {
+    throw new Error(
+      `${name}: ${entry.schema} uses "id"; the Angular CLI requires "$id"`,
+    );
+  }
+}
+
+console.log(
+  `verified ${Object.keys(collection.schematics).length} packaged schematic(s)`,
+);


### PR DESCRIPTION
`ng add @ng-icons/core` fails on a clean install of the released 35.0.0. Found while smoke-testing the v22 release in a fresh Angular 22 app.

```
$ npx ng add @ng-icons/core
Cannot find module '.../@ng-icons/core/schematics/schematics/ng-add/index'
```

Three independent faults, each stopping it before the schematic runs. I patched `node_modules` one at a time until it exited 0, so all three are confirmed necessary.

## 1. Doubled path segment in `collection.json`

The factory was `./schematics/ng-add/index#ngAdd`, but `collection.json` already lives in `schematics/`, so the engine resolved `schematics/schematics/ng-add/index`. Now `./ng-add/index#ngAdd`.

**Pre-existing** — identical in 33.4.0 and 34.0.0.

## 2. CommonJS schematics under `"type": "module"`

```
exports is not defined in ES module scope
```

ng-packagr 22 adds `"type": "module"` to the published `package.json`, so Node treats the CommonJS-compiled `.js` schematics as ESM. Added a nested `schematics/package.json` with `{"type":"commonjs"}`.

**This one is new in 35.0.0** — `type` is absent from 33.4.0 and 34.0.0.

## 3. Draft-04 `id` in the schema

```
NOT SUPPORTED: keyword "id", use "$id" for schema ID
```

`ng-add/schema.json` used `"id"`, which the CLI's validator rejects. Now `"$id"`.

**Pre-existing.**

## Why the tests missed all three

`ng-add/index.spec.ts` imports the factory directly and mocks `fs`, `path` and the schematics utilities. It never loads the packaged `collection.json`, so every one of these is invisible to it — and would stay invisible to any test added in that file.

So the guard is a build step, not a unit test. `verify-package.mjs` runs in `build-schematics` against the built output: it loads `collection.json`, resolves the factory the way the schematics engine does, asserts the export is callable, and rejects a draft-04 `id`. It fails the build rather than the test suite, because the artefact is what breaks.

## Also: the `cp` in build-schematics was doing damage

```
cp packages/core/schematics/**/*.json dist/packages/core/schematics/
```

`sh` expands `**` as `*`, so this matched exactly one file — `ng-add/schema.json` — and flattened it to a stray top-level `schema.json`. It never copied `collection.json` at all. ng-packagr's `assets: ["schematics/**/*.json"]` was doing the real copying correctly the whole time. Removed; the stray file goes with it.

## Verification

Packed `dist/packages/core` and installed the tarball into a **fresh** `ng new` Angular 22 app — no patching:

```
$ npx ng add @ng-icons/core --iconsets=heroicons --iconsets=lucide
Added @ng-icons/core dependency
Added @ng-icons/heroicons dependency
Added @ng-icons/lucide dependency
EXIT=0
```

Workspace `lint test build` green across 44 projects.

## Note on the eslint change

Adding `schematics/package.json` makes `@nx/dependency-checks` treat that folder as a package and demand dependency sections. Disabled the rule for that one path — it is a module-type marker, not a package.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `ng add @ng-icons/core` by repairing the schematics packaging so it runs on fresh Angular 22 apps. Adds a build-time check to prevent packaging regressions.

- **Bug Fixes**
  - Corrected `collection.json` factory path to `./ng-add/index#ngAdd`.
  - Marked schematics as CommonJS via `schematics/package.json` to avoid ESM/CJS mismatch.
  - Replaced schema `id` with `$id` to satisfy the Angular CLI validator.

- **Refactors**
  - Added `schematics/verify-package.mjs` to verify packaged factories and schema `$id` during build.
  - Removed the broken `cp` step; rely on `ng-packagr` assets. Disabled `@nx/dependency-checks` for `schematics/package.json`.

<sup>Written for commit 1fe377edea816ac5a9fc9662d8d0a3c760fb8147. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-icons/ng-icons/pull/264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

