### PR TITLE
refactor(documentation): migrate Stats service to signal resource APIs

### DIFF
--- a/apps/documentation/src/app/icons/icon-catalog.ts
+++ b/apps/documentation/src/app/icons/icon-catalog.ts
@@ -1,12 +1,6 @@
 import { isPlatformBrowser } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
-import {
-  computed,
-  inject,
-  Injectable,
-  PLATFORM_ID,
-  signal,
-} from '@angular/core';
+import { computed, inject, PLATFORM_ID, Service, signal } from '@angular/core';
 import { firstValueFrom } from 'rxjs';
 import { assetUrl } from '../shared/asset-url';
 import {
@@ -26,7 +20,7 @@ const DATA_DIR = 'assets/icons';
  * set load once (they power search across all sets and the ⌘K palette), and SVG
  * bodies load per variant only when icons from it are about to render.
  */
-@Injectable({ providedIn: 'root' })
+@Service()
 export class IconCatalog {
   private readonly http = inject(HttpClient);
   private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));

--- a/apps/documentation/src/app/shared/favourites.ts
+++ b/apps/documentation/src/app/shared/favourites.ts
@@ -1,8 +1,8 @@
-import { computed, Injectable } from '@angular/core';
+import { computed, Service } from '@angular/core';
 import { storedSignal } from './local-storage';
 
 /** Favourited icons, by constant name, kept in localStorage. */
-@Injectable({ providedIn: 'root' })
+@Service()
 export class Favourites {
   private readonly state = storedSignal<string[]>('ng-icons-favourites', []);
 

--- a/apps/documentation/src/app/shared/seo.ts
+++ b/apps/documentation/src/app/shared/seo.ts
@@ -1,5 +1,5 @@
 import { DOCUMENT } from '@angular/common';
-import { inject, Injectable } from '@angular/core';
+import { inject, Service } from '@angular/core';
 import { Meta, Title } from '@angular/platform-browser';
 
 export const SITE_NAME = 'Angular Icons';
@@ -36,7 +36,7 @@ export interface PageSeo {
  * hydration is invisible to crawlers and to the services that unfurl links,
  * which is how every route ended up sharing the index.html title.
  */
-@Injectable({ providedIn: 'root' })
+@Service()
 export class Seo {
   private readonly title = inject(Title);
   private readonly meta = inject(Meta);

--- a/apps/documentation/src/app/shared/stats.ts
+++ b/apps/documentation/src/app/shared/stats.ts
@@ -1,7 +1,8 @@
 import { isPlatformBrowser } from '@angular/common';
-import { HttpClient } from '@angular/common/http';
-import { inject, Injectable, PLATFORM_ID, signal } from '@angular/core';
-import { forkJoin } from 'rxjs';
+import { HttpClient, httpResource } from '@angular/common/http';
+import { computed, inject, PLATFORM_ID, Service, signal } from '@angular/core';
+import { rxResource } from '@angular/core/rxjs-interop';
+import { forkJoin, map } from 'rxjs';
 import { iconStats } from 'virtual:icon-stats';
 import { compact, lifetimeWindows } from './downloads';
 
@@ -17,57 +18,66 @@ export const ICON_STATS = iconStats;
  * replaced on load. Left to be bumped by hand, the all-time total sat at 4.0M
  * while the real figure passed 5M.
  */
-@Injectable({ providedIn: 'root' })
+@Service()
 export class Stats {
   private readonly http = inject(HttpClient);
   private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
 
-  readonly stars = signal('586');
-  readonly weekly = signal('108K');
-  readonly lifetime = signal('5.0M');
+  // Skipped while prerendering. Five requests to GitHub and npm per route
+  // slowed the build and made it depend on their rate limits, and the fetched
+  // values would have been baked into static HTML anyway.
+  private readonly enabled = signal(false);
+  private readonly shouldLoad = computed(
+    () => this.enabled() && this.isBrowser,
+  );
 
-  private loaded = false;
+  private readonly starsResource = httpResource<{ stargazers_count: number }>(
+    () =>
+      this.shouldLoad()
+        ? 'https://api.github.com/repos/ng-icons/ng-icons'
+        : undefined,
+  );
+
+  private readonly weeklyResource = httpResource<{ downloads: number }>(() =>
+    this.shouldLoad() ? this.downloadsUrl('last-week') : undefined,
+  );
+
+  // One request per 18-month window, summed: four today, five from 2027.
+  private readonly lifetimeResource = rxResource({
+    params: () => (this.shouldLoad() ? true : undefined),
+    stream: () =>
+      forkJoin(lifetimeWindows().map(window => this.downloads(window))).pipe(
+        map(points =>
+          points.reduce((total, point) => total + point.downloads, 0),
+        ),
+      ),
+  });
+
+  readonly stars = computed(() =>
+    this.starsResource.hasValue()
+      ? compact(this.starsResource.value().stargazers_count)
+      : '586',
+  );
+  readonly weekly = computed(() =>
+    this.weeklyResource.hasValue()
+      ? compact(this.weeklyResource.value().downloads)
+      : '108K',
+  );
+  readonly lifetime = computed(() =>
+    this.lifetimeResource.hasValue()
+      ? compact(this.lifetimeResource.value())
+      : '5.0M',
+  );
 
   load(): void {
-    // Skipped while prerendering. Five requests to GitHub and npm per route
-    // slowed the build and made it depend on their rate limits, and the fetched
-    // values would have been baked into static HTML anyway.
-    if (this.loaded || !this.isBrowser) {
-      return;
-    }
-    this.loaded = true;
+    this.enabled.set(true);
+  }
 
-    this.http
-      .get<{
-        stargazers_count: number;
-      }>('https://api.github.com/repos/ng-icons/ng-icons')
-      .subscribe({
-        next: repo => this.stars.set(compact(repo.stargazers_count)),
-        error: () => undefined,
-      });
-
-    this.downloads('last-week').subscribe({
-      next: point => this.weekly.set(compact(point.downloads)),
-      error: () => undefined,
-    });
-
-    // One request per 18-month window, summed: four today, five from 2027.
-    forkJoin(lifetimeWindows().map(window => this.downloads(window))).subscribe(
-      {
-        next: points =>
-          this.lifetime.set(
-            compact(
-              points.reduce((total, point) => total + point.downloads, 0),
-            ),
-          ),
-        error: () => undefined,
-      },
-    );
+  private downloadsUrl(period: string): string {
+    return `https://api.npmjs.org/downloads/point/${period}/@ng-icons/core`;
   }
 
   private downloads(period: string) {
-    return this.http.get<{ downloads: number }>(
-      `https://api.npmjs.org/downloads/point/${period}/@ng-icons/core`,
-    );
+    return this.http.get<{ downloads: number }>(this.downloadsUrl(period));
   }
 }

--- a/apps/documentation/src/app/shared/theme.ts
+++ b/apps/documentation/src/app/shared/theme.ts
@@ -1,5 +1,5 @@
 import { DOCUMENT, isPlatformBrowser } from '@angular/common';
-import { effect, inject, Injectable, PLATFORM_ID } from '@angular/core';
+import { effect, inject, PLATFORM_ID, Service } from '@angular/core';
 import { storedSignal } from './local-storage';
 
 export type Theme = 'light' | 'dark';
@@ -9,7 +9,7 @@ export type Theme = 'light' | 'dark';
  * index.html before first paint; this service reads back what that decided so
  * the two never disagree, and leaves the prerendered HTML untouched.
  */
-@Injectable({ providedIn: 'root' })
+@Service()
 export class ThemeService {
   private readonly document = inject(DOCUMENT);
   private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));


### PR DESCRIPTION
Replace manual HttpClient.subscribe() calls with httpResource/rxResource so stars and download counts are derived signals instead of hand-written signal.set() calls in subscribe callbacks.