### PR TITLE
ci: publish preview packages for pull requests with pkg.pr.new

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,3 +62,27 @@ jobs:
       # builds in seconds, so always build it: otherwise a bad icon set only
       # surfaces on `main`, during the deploy.
       - run: pnpm exec nx build documentation
+
+      # Publish a preview build of the packages this commit touched, so a pull
+      # request can be installed and tried before it is released:
+      #
+      #   pnpm add https://pkg.pr.new/@ng-icons/core@<sha>
+      #
+      # `nx affected` above already left dist/packages holding just those
+      # packages and whatever they build against, so the glob scopes itself: a
+      # PR touching one icon set uploads a few MB rather than the ~76 MB all 43
+      # packages weigh together. A change to a shared input, such as the root
+      # package.json or the lockfile, affects every project and does publish all
+      # of them.
+      #
+      # Skipped when nothing in packages/ was affected, e.g. a docs-only or
+      # workflow-only PR, because the glob would match nothing and the CLI
+      # treats an empty publish as an error.
+      #
+      # One-time setup: install the pkg.pr.new GitHub App on the repository
+      # (https://github.com/apps/pkg-pr-new). There is no token or secret - it
+      # authenticates from the workflow run itself, which is also why this works
+      # on pull requests from forks.
+      - name: Publish preview packages
+        if: hashFiles('dist/packages/*/package.json') != ''
+        run: pnpm exec pkg-pr-new publish --commentWithSha './dist/packages/*'

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "marked-shiki": "1.2.1",
     "ng-packagr": "22.0.1",
     "nx": "23.1.0",
+    "pkg-pr-new": "^0.0.88",
     "playwright": "^1.56.0",
     "postcss": "^8.4.5",
     "postcss-import": "~14.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -327,6 +327,9 @@ importers:
       nx:
         specifier: 23.1.0
         version: 23.1.0(@swc-node/register@1.12.0(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.27)(typescript@6.0.3))(@swc/core@1.15.8(@swc/helpers@0.5.23))
+      pkg-pr-new:
+        specifier: ^0.0.88
+        version: 0.0.88
       playwright:
         specifier: ^1.56.0
         version: 1.56.0
@@ -10313,6 +10316,10 @@ packages:
   pkg-dir@8.0.0:
     resolution: {integrity: sha512-4peoBq4Wks0riS0z8741NVv+/8IiTvqnZAr8QGgtdifrtpdXbNw/FxRS1l6NFqm4EMzuS0EDqNNx4XGaz8cuyQ==}
     engines: {node: '>=18'}
+
+  pkg-pr-new@0.0.88:
+    resolution: {integrity: sha512-Xc6PMJ2gher0WZP+rtjefFk26hIb7V1PTLL30bmy1Z2vsRmSvqiss7Ag1XUdyplTGYzIlFNJp4L3vMNmK44N6g==}
+    hasBin: true
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
@@ -25045,6 +25052,8 @@ snapshots:
   pkg-dir@8.0.0:
     dependencies:
       find-up-simple: 1.0.1
+
+  pkg-pr-new@0.0.88: {}
 
   pkg-types@1.3.1:
     dependencies:


### PR DESCRIPTION
Every pull request now gets installable builds of the packages it touches, so a change can be tried in a real application before it is released:

```
pnpm add https://pkg.pr.new/@ng-icons/core@<sha>
```

[pkg.pr.new](https://github.com/stackblitz-labs/pkg.pr.new) posts a comment on the PR with a link per package. This is particularly useful for icon sets, where "does this actually render" is hard to answer from a diff.

## How it works

One step at the end of the existing CI job, plus `pkg-pr-new` as a dev dependency:

```yaml
- name: Publish preview packages
  if: hashFiles('dist/packages/*/package.json') != ''
  run: pnpm exec pkg-pr-new publish --commentWithSha './dist/packages/*'
```

There is no separate build. `nx affected -t build` already leaves `dist/packages` holding exactly the affected packages, so the glob scopes itself. Checked with `nx show projects --affected`:

| A PR touching | Affects | Publishes |
| --- | --- | --- |
| one icon set | `["mono-icons"]` | that set, a few MB |
| docs only | `["documentation"]` | nothing, step skipped |
| a workflow | `["ng-icons"]` | nothing, step skipped |
| the root `package.json` or lockfile | all 45 | all 43 packages, ~76 MB |

That last row is why this PR's own run will publish everything once and post a 43 row comment. Later PRs won't. `documentation`'s build target has no `dependsOn`, so it can't drag extra packages into `dist` either.

The `if:` guard is needed because the CLI treats a publish that matches no package as an error.

## Notes on the flags

- `--commentWithSha` pins the links in the comment to the commit rather than the PR number, so a reinstall after a force push can't quietly resolve to different content. Both URL forms are published either way.
- Compact URLs (`pkg.pr.new/@ng-icons/core@<sha>`) need the package to be on npm with a resolvable `repository` field. Ours publish `git+https://github.com/ng-icons/ng-icons.git`, so this works. A brand new icon set not yet on npm makes the run fall back to long URLs with a warning, not an error.
- `--peerDeps` is deliberately not used. The README implies it points cross package `peerDependencies` at the preview builds, but the CLI actually resolves them to `previewVersion ?? pJson.version`, so without `--previewVersion` it only pins the peer to an exact version. Worth knowing if we ever add `--previewVersion`.

## Setup

The pkg.pr.new GitHub App is already installed on the repository. There is no token or secret to add, which is also why this works on pull requests from forks.

`ci.yml` is deliberately left without a `permissions:` block: pkg-pr-new needs none, and adding one would also have to grant `actions: read` for `nrwl/nx-set-shas`.

## Verification

The YAML parses and the step is well formed. Two things can only be confirmed once this runs on CI: the publish itself (the CLI refuses to run outside GitHub Actions) and the `hashFiles` guard, which only evaluates in the Actions runtime.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CI step that publishes installable preview builds of the packages a pull request touches via pkg.pr.new, so a change can be tried in a real app before release.

**New Features**
- Every package-affecting PR now gets preview installs, e.g. `pnpm add https://pkg.pr.new/@ng-icons/core@<sha>`, with a comment posted on the PR.
- Reuses the `nx affected -t build` output, so publishing is scoped to changed packages and skipped when a PR affects no packages.
- Adds `pkg-pr-new` as a dev dependency; the pkg.pr.new GitHub App is already installed, so no token is needed and fork PRs work.

<sup>Written for commit 76eeac30453efd8e01a176d217b68ee8c1af3552. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-icons/ng-icons/pull/271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

